### PR TITLE
Refactoring to get rid of deprecated APIs in KS 1.0.0 and fix warnings

### DIFF
--- a/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
@@ -1,185 +1,55 @@
 package com.lightbend.kafka.scala.streams
 
-import ImplicitConversions._
-import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.kstream._
-import org.apache.kafka.streams.processor.StateStoreSupplier
-import org.apache.kafka.streams.state.{KeyValueStore, SessionStore, WindowStore}
+import org.apache.kafka.streams.state.KeyValueStore
+import org.apache.kafka.common.utils.Bytes
+import ImplicitConversions._
+import Predef._
+
 
 class KGroupedStreamS[K, V](inner: KGroupedStream[K, V]) {
 
-/*
-  def count(storeName: String): KTableS[K, Long] = {
-    inner.count(storeName)
-      .mapValues[Long](javaLong => Long.box(javaLong))
+  def count(): KTableS[K, Long] = {
+    val c: KTableS[K, java.lang.Long] = inner.count()
+    c.mapValues[Long, java.lang.Long, Long](Long2long(_))
   }
 
-  def count(storeSupplier: StateStoreSupplier[KeyValueStore[_, _]]): KTableS[K, Long] = {
-    inner.count(storeSupplier)
-      .mapValues[Long](javaLong => Long.box(javaLong))
-  }
+  def count(materialized: Materialized[K, Long, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, Long] = 
+    inner.count(materialized)
 
-  def count[W <: Window](windows: Windows[W],
-                         storeName: String): KTableS[Windowed[K], Long] = {
-    inner.count[W](windows, storeName)
-      .mapValues[Long](javaLong => Long.box(javaLong))
-  }
-
-  def count[W <: Window](windows: Windows[W],
-                         storeSupplier: StateStoreSupplier[WindowStore[_, _]]): KTableS[Windowed[K], Long] = {
-    inner.count[W](windows, storeSupplier)
-      .mapValues[Long](javaLong => Long.box(javaLong))
-  }
-
-  def count(sessionWindows: SessionWindows, storeName: String): KTableS[Windowed[K], Long] = {
-    inner.count(sessionWindows, storeName)
-      .mapValues[Long](javaLong => Long.box(javaLong))
-  }
-
-  def count(sessionWindows: SessionWindows,
-            storeSupplier: StateStoreSupplier[SessionStore[_, _]]): KTableS[Windowed[K], Long] = {
-    inner.count(sessionWindows, storeSupplier)
-      .mapValues[Long](javaLong => Long.box(javaLong))
-  }
-*/
-  def reduce(reducer: (V, V) => V,
-             storeName: String): KTableS[K, V] = {
-    val reducerJ: Reducer[V] = new Reducer[V]{
-      override def apply(value1: V, value2: V): V = reducer(value1, value2)
-    }
-    inner.reduce(reducerJ, storeName)
+  def reduce(reducer: (V, V) => V): KTableS[K, V] = {
+    val reducerJ: Reducer[V] = (v1: V, v2: V) => reducer(v1, v2)
+    inner.reduce(reducerJ)
   }
 
   def reduce(reducer: (V, V) => V,
-             storeSupplier: StateStoreSupplier[KeyValueStore[_, _]]): KTableS[K, V] = {
-    val reducerJ: Reducer[V] = new Reducer[V]{
-      override def apply(value1: V, value2: V): V = reducer(value1, value2)
-    }
-    inner.reduce(reducerJ, storeSupplier)
-  }
+    materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, V] = {
 
-  def reduce[W <: Window](reducer: (V, V) => V,
-                          windows: Windows[W],
-                          storeName: String): KTableS[Windowed[K], V] = {
-    val reducerJ: Reducer[V] = new Reducer[V]{
-      override def apply(value1: V, value2: V): V = reducer(value1, value2)
-    }
-    inner.reduce(reducerJ, windows, storeName)
-  }
-
-  def reduce[W <: Window](reducer: (V, V) => V,
-                          windows: Windows[W],
-                          storeSupplier: StateStoreSupplier[WindowStore[_, _]]): KTableS[Windowed[K], V] = {
-    val reducerJ: Reducer[V] = new Reducer[V]{
-      override def apply(value1: V, value2: V): V = reducer(value1, value2)
-    }
-    inner.reduce(reducerJ, windows, storeSupplier)
+    val reducerJ: Reducer[V] = (v1: V, v2: V) => reducer(v1, v2)
+    inner.reduce(reducerJ, materialized)
   }
 
   def reduce(reducer: (V, V) => V,
-             sessionWindows: SessionWindows,
-             storeName: String): KTableS[Windowed[K], V] = {
-    val reducerJ: Reducer[V] = new Reducer[V]{
-      override def apply(value1: V, value2: V): V = reducer(value1, value2)
-    }
-    inner.reduce(reducerJ, sessionWindows, storeName)
+    storeName: String): KTableS[K, V] = {
+
+    val reducerJ: Reducer[V] = (v1: V, v2: V) => reducer(v1, v2)
+    inner.reduce(reducerJ, Materialized.as[K, V, KeyValueStore[Bytes, Array[Byte]]](storeName))
   }
 
-  def reduce(reducer: (V, V) => V,
-             sessionWindows: SessionWindows,
-             storeSupplier: StateStoreSupplier[SessionStore[_, _]]): KTableS[Windowed[K], V] = {
-    val reducerJ: Reducer[V] = new Reducer[V]{
-      override def apply(value1: V, value2: V): V = reducer(value1, value2)
-    }
-    inner.reduce(reducerJ, sessionWindows, storeSupplier)
+  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
+    aggregator: (SK, SV, VR) => VR): KTableS[K, VR] = {
+
+    val initializerJ: Initializer[VR] = () => initializer()
+    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
+    inner.aggregate(initializerJ, aggregatorJ)
   }
 
-  def aggregate[VR](initializer: () => VR,
-                    aggregator: (K, V, VR) => VR,
-                    aggValueSerde: Serde[VR],
-                    storeName: String): KTableS[K, VR] = {
-    val initializerJ: Initializer[VR] = new Initializer[VR]{
-      override def apply(): VR = initializer()
-    }
-    val aggregatorJ: Aggregator[K, V, VR] = new Aggregator[K, V, VR]{
-      override def apply(key: K, value: V, aggregate: VR): VR = aggregator(key, value, aggregate)
-    }
-    inner.aggregate(initializerJ, aggregatorJ, aggValueSerde, storeName)
-  }
+  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
+    aggregator: (SK, SV, VR) => VR,
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, VR] = {
 
-  def aggregate[VR](initializer: () => VR,
-                    aggregator: (K, V, VR) => VR,
-                    storeSupplier: StateStoreSupplier[KeyValueStore[_, _]]): KTableS[K, VR] = {
-    val initializerJ: Initializer[VR] = new Initializer[VR]{
-      override def apply(): VR = initializer()
-    }
-    val aggregatorJ: Aggregator[K, V, VR] = new Aggregator[K, V, VR]{
-      override def apply(key: K, value: V, aggregate: VR): VR = aggregator(key, value, aggregate)
-    }
-    inner.aggregate(initializerJ, aggregatorJ, storeSupplier)
+    val initializerJ: Initializer[VR] = () => initializer()
+    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
+    inner.aggregate(initializerJ, aggregatorJ, materialized)
   }
-
-  def aggregate[W <: Window, VR](initializer: () => VR,
-                                 aggregator: (K, V, VR) => VR,
-                                 windows: Windows[W],
-                                 aggValueSerde: Serde[VR],
-                                 storeName: String): KTableS[Windowed[K], VR] = {
-    val initializerJ: Initializer[VR] = new Initializer[VR]{
-      override def apply(): VR = initializer()
-    }
-    val aggregatorJ: Aggregator[K, V, VR] = new Aggregator[K, V, VR]{
-      override def apply(key: K, value: V, aggregate: VR): VR = aggregator(key, value, aggregate)
-    }
-    inner.aggregate(initializerJ, aggregatorJ, windows, aggValueSerde, storeName)
-  }
-
-  def aggregate[W <: Window, VR](initializer: () => VR,
-                                 aggregator: (K, V, VR) => VR,
-                                 windows: Windows[W],
-                                 storeSupplier: StateStoreSupplier[WindowStore[_, _]]): KTableS[Windowed[K], VR] = {
-    val initializerJ: Initializer[VR] = new Initializer[VR]{
-      override def apply(): VR = initializer()
-    }
-    val aggregatorJ: Aggregator[K, V, VR] = new Aggregator[K, V, VR]{
-      override def apply(key: K, value: V, aggregate: VR): VR = aggregator(key, value, aggregate)
-    }
-    inner.aggregate(initializerJ, aggregatorJ, windows, storeSupplier)
-  }
-
-  def aggregate[T](initializer: Initializer[T],
-                   aggregator: (K, V, T) => T,
-                   sessionMerger: (K, T, T) => T,
-                   sessionWindows: SessionWindows,
-                   aggValueSerde: Serde[T],
-                   storeName: String): KTableS[Windowed[K], T] = {
-    val initializerJ: Initializer[T] = new Initializer[T]{
-      override def apply(): T = initializer()
-    }
-    val aggregatorJ: Aggregator[K, V, T] = new Aggregator[K, V, T]{
-      override def apply(key: K, value: V, aggregate: T): T = aggregator(key, value, aggregate)
-    }
-    val sessionMergerJ: Merger[K, T] = new Merger[K, T]{
-      override def apply(aggKey: K, aggOne: T, aggTwo: T): T = sessionMerger(aggKey, aggOne, aggTwo)
-    }
-    inner.aggregate(initializerJ, aggregatorJ, sessionMergerJ, sessionWindows, aggValueSerde, storeName)
-  }
-
-  def aggregate[T](initializer: Initializer[T],
-                   aggregator: (K, V, T) => T,
-                   sessionMerger: Merger[_ >: K, T],
-                   sessionWindows: SessionWindows,
-                   aggValueSerde: Serde[T],
-                   storeSupplier: StateStoreSupplier[SessionStore[_, _]]): KTableS[Windowed[K], T] = {
-    val initializerJ: Initializer[T] = new Initializer[T]{
-      override def apply(): T = initializer()
-    }
-    val aggregatorJ: Aggregator[K, V, T] = new Aggregator[K, V, T]{
-      override def apply(key: K, value: V, aggregate: T): T = aggregator(key, value, aggregate)
-    }
-    val sessionMergerJ: Merger[K, T] = new Merger[K, T]{
-      override def apply(aggKey: K, aggOne: T, aggTwo: T): T = sessionMerger(aggKey, aggOne, aggTwo)
-    }
-    inner.aggregate(initializerJ, aggregatorJ, sessionMergerJ, sessionWindows, aggValueSerde, storeSupplier)
-  }
-
 }

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedTableS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedTableS.scala
@@ -1,86 +1,55 @@
 package com.lightbend.kafka.scala.streams
 
 import ImplicitConversions._
-import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.kstream._
-import org.apache.kafka.streams.state.{KeyValueStore, StoreSupplier}
+import org.apache.kafka.streams.state.KeyValueStore
+import org.apache.kafka.common.utils.Bytes
 
 class KGroupedTableS[K, V](inner: KGroupedTable[K, V]) {
-/*
-  def count(storeName: String): KTableS[K, Long] = {
-    inner.count(storeName)
-      .mapValues[Long](javaLong => Long.box(javaLong))
+
+  def count(): KTableS[K, Long] = {
+    val c: KTableS[K, java.lang.Long] = inner.count()
+    c.mapValues[Long, java.lang.Long, Long](Long2long(_))
   }
 
-  def count(storeSupplier: StateStoreSupplier[KeyValueStore[_, _]]): KTableS[K, Long] = {
-    inner.count(storeSupplier)
-      .mapValues[Long](javaLong => Long.box(javaLong))
-  }
-*/
+  def count(materialized: Materialized[K, Long, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, Long] = 
+    inner.count(materialized)
+
   def reduce(adder: (V, V) => V,
-             subtractor: (V, V) => V,
-             storeName: String): KTableS[K, V] = {
-    val adderJ: Reducer[V] = new Reducer[V]{
-      override def apply(v1: V, v2: V): V = adder(v1, v2)
-    }
-    val subtractorJ: Reducer[V] = new Reducer[V]{
-      override def apply(v1: V, v2: V): V = subtractor(v1, v2)
-    }
-    inner.reduce(adderJ, subtractorJ, storeName)
+    subtractor: (V, V) => V): KTableS[K, V] = {
+
+    val adderJ: Reducer[V] = (v1: V, v2: V) => adder(v1, v2)
+    val subtractorJ: Reducer[V] = (v1: V, v2: V) => subtractor(v1, v2)
+    inner.reduce(adderJ, subtractorJ)
   }
 
-  def reduce(adder: Reducer[V],
-             subtractor: Reducer[V],
-             storeSupplier: StoreSupplier[KeyValueStore[_, _]]): KTableS[K, V] = {
-    val adderJ: Reducer[V] = new Reducer[V]{
-      override def apply(v1: V, v2: V): V = adder(v1, v2)
-    }
-    val subtractorJ: Reducer[V] = new Reducer[V]{
-      override def apply(v1: V, v2: V): V = subtractor(v1, v2)
-    }
-    inner.reduce(adderJ, subtractorJ, storeSupplier)
+  def reduce(adder: (V, V) => V,
+    subtractor: (V, V) => V,
+    materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, V] = {
+
+    val adderJ: Reducer[V] = (v1: V, v2: V) => adder(v1, v2)
+    val subtractorJ: Reducer[V] = (v1: V, v2: V) => subtractor(v1, v2)
+    inner.reduce(adderJ, subtractorJ, materialized)
   }
 
-  def aggregate[VR](initializer: () => VR,
-                    adder: (K, V, VR) => VR,
-                    subtractor: (K, V, VR) => VR,
-                    storeName: String): KTableS[K, VR] = {
-    val initializerJ: Initializer[VR] = new Initializer[VR]{
-      override def apply(): VR = initializer()
-    }
-    val adderJ: Aggregator[K, V, VR] = new Aggregator[K, V, VR]{
-      override def apply(key: K, value: V, aggregate: VR): VR = adder(key, value, aggregate)
-    }
-    val subtractorJ: Aggregator[K, V, VR] = new Aggregator[K, V, VR]{
-      override def apply(key: K, value: V, aggregate: VR): VR = subtractor(key, value, aggregate)
-    }
-    inner.aggregate(initializerJ, adderJ, subtractorJ, storeName)
-  }
+  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
+    adder: (SK, SV, VR) => VR,
+    subtractor: (SK, SV, VR) => VR): KTableS[K, VR] = {
 
-  def aggregate[VR](initializer: () => VR,
-                    adder: (K, V, VR) => VR,
-                    subtractor: (K, V, VR) => VR,
-                    aggValueSerde: Serde[VR],
-                    storeName: String): KTableS[K, VR] = {
-    val initializerJ: Initializer[VR] = new Initializer[VR]{
-      override def apply(): VR = initializer()
-    }
-    val adderJ: Aggregator[K, V, VR] = new Aggregator[K, V, VR]{
-      override def apply(key: K, value: V, aggregate: VR): VR = adder(key, value, aggregate)
-    }
-    val subtractorJ: Aggregator[K, V, VR] = new Aggregator[K, V, VR]{
-      override def apply(key: K, value: V, aggregate: VR): VR = subtractor(key, value, aggregate)
-    }
-    inner.aggregate(initializerJ, adderJ, subtractorJ, aggValueSerde, storeName)
-  }
-/*
-  def aggregate[VR](initializer: () => VR,
-                    adder: (K, V, VR) => VR,
-                    subtractor: (K, V, VR) => VR,
-                    storeSupplier: StoreSupplier[KeyValueStore[_, _]]): KTableS[K, VR] = {
     val initializerJ: Initializer[VR] = () => initializer()
     val adderJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => adder(k, v, va)
     val subtractorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => subtractor(k, v, va)
-    inner.aggregate(initializerJ, adderJ, subtractorJ, storeSupplier)
-  } */
+    inner.aggregate(initializerJ, adderJ, subtractorJ)
+  }
+
+  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
+    adder: (SK, SV, VR) => VR,
+    subtractor: (SK, SV, VR) => VR,
+    materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, VR] = {
+
+    val initializerJ: Initializer[VR] = () => initializer()
+    val adderJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => adder(k, v, va)
+    val subtractorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => subtractor(k, v, va)
+    inner.aggregate(initializerJ, adderJ, subtractorJ, materialized)
+  }
 }

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KTableS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KTableS.scala
@@ -24,10 +24,8 @@ class KTableS[K, V](val inner: KTable[K, V]) {
     inner.filterNot(predicateJ)
   }
 
-  def mapValues[VR](mapper: (V) => VR): KTable[K, VR] = {
-    def mapperJ: ValueMapper[V, VR] = new ValueMapper[V, VR]{
-      override def apply(value: V): VR = mapper(value)
-    }
+  def mapValues[VR, A >: V, B <: VR](mapper: (A) => B): KTable[K, VR] = {
+    def mapperJ: ValueMapper[V, VR] = (v) => mapper(v)
     inner.mapValues(mapperJ)
   }
 


### PR DESCRIPTION
This PR is a **partial** implementation of the following:

1. get rid of deprecated APIs in Kafka Streams 1.0.0
2. some refactoring from original code base
3. fix warnings by migrating to newer APIs in Kafka Streams 1.0.0