### PR TITLE
More wrappers added, better type inferencing

### DIFF
--- a/src/main/scala/com/lightbend/kafka/scala/streams/ImplicitConversions.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/ImplicitConversions.scala
@@ -1,6 +1,6 @@
 package com.lightbend.kafka.scala.streams
 
-import org.apache.kafka.streams.kstream.{KGroupedStream, KGroupedTable, KStream, KTable}
+import org.apache.kafka.streams.kstream.{KGroupedStream, KGroupedTable, KStream, KTable, SessionWindowedKStream, TimeWindowedKStream}
 
 import scala.language.implicitConversions
 
@@ -12,10 +12,15 @@ object ImplicitConversions {
   implicit def wrapKGroupedStream[K, V](inner: KGroupedStream[K, V]): KGroupedStreamS[K, V] =
     new KGroupedStreamS[K, V](inner)
 
+  implicit def wrapSessionWindowedKStream[K, V](inner: SessionWindowedKStream[K, V]): SessionWindowedKStreamS[K, V] =
+    new SessionWindowedKStreamS[K, V](inner)
+
+  implicit def wrapTimeWindowedKStream[K, V](inner: TimeWindowedKStream[K, V]): TimeWindowedKStreamS[K, V] =
+    new TimeWindowedKStreamS[K, V](inner)
+
   implicit def wrapKTable[K, V](inner: KTable[K, V]): KTableS[K, V] =
     new KTableS[K, V](inner)
 
   implicit def wrapKGroupedTable[K, V](inner: KGroupedTable[K, V]): KGroupedTableS[K, V] =
     new KGroupedTableS[K, V](inner)
-
 }

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
@@ -51,4 +51,10 @@ class KGroupedStreamS[K, V](inner: KGroupedStream[K, V]) {
     val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
     inner.aggregate(initializerJ, aggregatorJ, materialized)
   }
+
+  def windowedBy(windows: SessionWindows): SessionWindowedKStreamS[K, V] =
+    inner.windowedBy(windows)
+
+  def windowedBy[W <: Window](windows: Windows[W]): TimeWindowedKStreamS[K, V] =
+    inner.windowedBy(windows)
 }

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KStreamS.scala
@@ -78,10 +78,10 @@ class KStreamS[K, V](val inner: KStream[K, V]) {
   def through(topic: String,
     produced: Produced[K, V]): KStreamS[K, V] = inner.through(topic, produced)
 
-  def to(topic: String): KStreamS[K, V] = inner.through(topic)
+  def to(topic: String): Unit = inner.to(topic)
 
   def to(topic: String,
-    produced: Produced[K, V]): KStreamS[K, V] = inner.through(topic, produced)
+    produced: Produced[K, V]): Unit = inner.to(topic, produced)
 
   def transform[K1, V1](transformerSupplier: () => Transformer[K, V, (K1, V1)],
                         stateStoreNames: String*): KStreamS[K1, V1] = {
@@ -121,6 +121,9 @@ class KStreamS[K, V](val inner: KStream[K, V]) {
 
   def groupByKey(): KGroupedStreamS[K, V] =
     inner.groupByKey()
+
+  def groupByKey(serialized: Serialized[K, V]): KGroupedStreamS[K, V] =
+    inner.groupByKey(serialized)
 
   def groupBy[KR, SK >: K, SV >: V](selector: (SK, SV) => KR): KGroupedStreamS[KR, V] = {
     val selectorJ: KeyValueMapper[SK, SV, KR] = (k: SK, v: SV) => selector(k, v)

--- a/src/main/scala/com/lightbend/kafka/scala/streams/SessionWindowedKStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/SessionWindowedKStreamS.scala
@@ -1,0 +1,52 @@
+package com.lightbend.kafka.scala.streams
+
+import org.apache.kafka.streams.kstream._
+import org.apache.kafka.streams.state.SessionStore
+import org.apache.kafka.common.utils.Bytes
+
+import scala.collection.JavaConverters._
+import ImplicitConversions._
+
+class SessionWindowedKStreamS[K, V](val inner: SessionWindowedKStream[K, V]) {
+
+  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
+    aggregator: (SK, SV, VR) => VR,
+    merger: (SK, VR, VR) => VR): KTableS[Windowed[K], VR] = {
+
+    val initializerJ: Initializer[VR] = () => initializer()
+    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
+    val mergerJ: Merger[SK, VR] = (k: SK, v1: VR, v2: VR) => merger(k, v1, v2)
+    inner.aggregate(initializerJ, aggregatorJ, mergerJ)
+  }
+
+  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
+    aggregator: (SK, SV, VR) => VR,
+    merger: (SK, VR, VR) => VR,
+    materialized: Materialized[K, VR, SessionStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], VR] = {
+
+    val initializerJ: Initializer[VR] = () => initializer()
+    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
+    val mergerJ: Merger[SK, VR] = (k: SK, v1: VR, v2: VR) => merger(k, v1, v2)
+    inner.aggregate(initializerJ, aggregatorJ, mergerJ, materialized)
+  }
+
+  def count(): KTableS[Windowed[K], Long] = {
+    val c: KTableS[Windowed[K], java.lang.Long] = inner.count()
+    c.mapValues[Long, java.lang.Long, Long](Long2long(_))
+  }
+
+  def count(materialized: Materialized[K, Long, SessionStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], Long] = 
+    inner.count(materialized)
+
+  def reduce(reducer: (V, V) => V): KTableS[Windowed[K], V] = {
+    val reducerJ: Reducer[V] = (v1: V, v2: V) => reducer(v1, v2)
+    inner.reduce(reducerJ)
+  }
+
+  def reduce(reducer: (V, V) => V,
+    materialized: Materialized[K, V, SessionStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], V] = {
+
+    val reducerJ: Reducer[V] = (v1: V, v2: V) => reducer(v1, v2)
+    inner.reduce(reducerJ, materialized)
+  }
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
@@ -11,22 +11,26 @@ import org.apache.kafka.streams.{Consumed, StreamsBuilder, Topology}
 
 import scala.collection.JavaConverters._
 
-class StreamsBuilderS {
+object StreamsBuilderS {
 
   val inner = new StreamsBuilder
 
-  def streamS[K, V](topics: String*) : KStreamS[K, V] = {
+  def stream[K, V](topics: String*) : KStreamS[K, V] = {
      inner.stream[K, V](topics.asJava)
   }
 
-  def streamS[K, V](offsetReset: Topology.AutoOffsetReset,
+  def stream[K, V](topics: List[String], consumed: Consumed[K, V]) : KStreamS[K, V] = {
+     inner.stream[K, V](topics.asJava, consumed)
+  }
+
+  def stream[K, V](offsetReset: Topology.AutoOffsetReset,
                    topics: String*) : KStreamS[K, V] =
     inner.stream[K, V](topics.asJava, Consumed.`with`[K,V](offsetReset))
 
-  def streamS[K, V](topicPattern: Pattern) : KStreamS[K, V] =
+  def stream[K, V](topicPattern: Pattern) : KStreamS[K, V] =
     inner.stream[K, V](topicPattern)
 
-  def streamS[K, V](offsetReset: Topology.AutoOffsetReset, topicPattern: Pattern): KStreamS[K, V] =
+  def stream[K, V](offsetReset: Topology.AutoOffsetReset, topicPattern: Pattern): KStreamS[K, V] =
     inner.stream[K, V](topicPattern, Consumed.`with`[K,V](offsetReset))
 
   def table[K, V](topic: String) : KTableS[K, V] = inner.table[K, V](topic)
@@ -47,3 +51,5 @@ class StreamsBuilderS {
 
   def build() : Topology = inner.build()
 }
+
+

--- a/src/main/scala/com/lightbend/kafka/scala/streams/TimeWindowedKStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/TimeWindowedKStreamS.scala
@@ -1,0 +1,48 @@
+package com.lightbend.kafka.scala.streams
+
+import org.apache.kafka.streams.kstream._
+import org.apache.kafka.streams.state.WindowStore
+import org.apache.kafka.common.utils.Bytes
+
+import scala.collection.JavaConverters._
+import ImplicitConversions._
+
+class TimeWindowedKStreamS[K, V](val inner: TimeWindowedKStream[K, V]) {
+
+  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
+    aggregator: (SK, SV, VR) => VR): KTableS[Windowed[K], VR] = {
+
+    val initializerJ: Initializer[VR] = () => initializer()
+    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
+    inner.aggregate(initializerJ, aggregatorJ)
+  }
+
+  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
+    aggregator: (SK, SV, VR) => VR,
+    materialized: Materialized[K, VR, WindowStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], VR] = {
+
+    val initializerJ: Initializer[VR] = () => initializer()
+    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
+    inner.aggregate(initializerJ, aggregatorJ, materialized)
+  }
+
+  def count(): KTableS[Windowed[K], Long] = {
+    val c: KTableS[Windowed[K], java.lang.Long] = inner.count()
+    c.mapValues[Long, java.lang.Long, Long](Long2long(_))
+  }
+
+  def count(materialized: Materialized[K, Long, WindowStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], Long] = 
+    inner.count(materialized)
+
+  def reduce(reducer: (V, V) => V): KTableS[Windowed[K], V] = {
+    val reducerJ: Reducer[V] = (v1: V, v2: V) => reducer(v1, v2)
+    inner.reduce(reducerJ)
+  }
+
+  def reduce(reducer: (V, V) => V,
+    materialized: Materialized[K, V, WindowStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], V] = {
+
+    val reducerJ: Reducer[V] = (v1: V, v2: V) => reducer(v1, v2)
+    inner.reduce(reducerJ, materialized)
+  }
+}


### PR DESCRIPTION
This PR does the following:

1. Adds more classes as wrappers
2. More refactoring

Checked for type inferencing. Much better compared to using native Java APIs. I used this wrapper library to change one part of the `kstream` application of `fdp-sample-apps`. Looks much better than using native Java APIs.

**Still to do:**

1. Tests (maybe using an embedded Kafka)
2. I think we can make some of the APIs better - will try to add some helpers as well