### PR TITLE
Type refinements, start of unit test infrastructure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,4 +14,11 @@ libraryDependencies += "org.apache.kafka" % "kafka-streams" % "1.0.0"
 libraryDependencies += "org.slf4j" % "slf4j-log4j12" % "1.7.25"
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
 
+libraryDependencies += "org.apache.kafka" % "kafka_2.12" % "1.0.0" % "test"
+libraryDependencies += "org.apache.curator" % "curator-test" % "4.0.0" % "test"
+libraryDependencies += "io.monix" %% "minitest" % "2.0.0" % "test"
+libraryDependencies += "io.monix" %% "minitest-laws" % "2.0.0" % "test"
+
+testFrameworks += new TestFramework("minitest.runner.Framework")
+
 publishTo := Some(Resolver.file("file", new File(Path.userHome.absolutePath + "/.m2/repository")))

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
@@ -10,7 +10,7 @@ class KGroupedStreamS[K, V](inner: KGroupedStream[K, V]) {
 
   def count(): KTableS[K, Long] = {
     val c: KTableS[K, java.lang.Long] = inner.count()
-    c.mapValues[Long, java.lang.Long, Long](Long2long(_))
+    c.mapValues[Long](Long2long(_))
   }
 
   def count(materialized: Materialized[K, Long, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, Long] = 
@@ -35,16 +35,16 @@ class KGroupedStreamS[K, V](inner: KGroupedStream[K, V]) {
     inner.reduce(reducerJ, Materialized.as[K, V, KeyValueStore[Bytes, Array[Byte]]](storeName))
   }
 
-  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
-    aggregator: (SK, SV, VR) => VR): KTableS[K, VR] = {
+  def aggregate[VR](initializer: () => VR,
+    aggregator: (K, V, VR) => VR): KTableS[K, VR] = {
 
     val initializerJ: Initializer[VR] = () => initializer()
     val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
     inner.aggregate(initializerJ, aggregatorJ)
   }
 
-  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
-    aggregator: (SK, SV, VR) => VR,
+  def aggregate[VR](initializer: () => VR,
+    aggregator: (K, V, VR) => VR,
     materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, VR] = {
 
     val initializerJ: Initializer[VR] = () => initializer()

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedTableS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedTableS.scala
@@ -9,7 +9,7 @@ class KGroupedTableS[K, V](inner: KGroupedTable[K, V]) {
 
   def count(): KTableS[K, Long] = {
     val c: KTableS[K, java.lang.Long] = inner.count()
-    c.mapValues[Long, java.lang.Long, Long](Long2long(_))
+    c.mapValues[Long](Long2long(_))
   }
 
   def count(materialized: Materialized[K, Long, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, Long] = 
@@ -32,9 +32,9 @@ class KGroupedTableS[K, V](inner: KGroupedTable[K, V]) {
     inner.reduce(adderJ, subtractorJ, materialized)
   }
 
-  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
-    adder: (SK, SV, VR) => VR,
-    subtractor: (SK, SV, VR) => VR): KTableS[K, VR] = {
+  def aggregate[VR](initializer: () => VR,
+    adder: (K, V, VR) => VR,
+    subtractor: (K, V, VR) => VR): KTableS[K, VR] = {
 
     val initializerJ: Initializer[VR] = () => initializer()
     val adderJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => adder(k, v, va)
@@ -42,9 +42,9 @@ class KGroupedTableS[K, V](inner: KGroupedTable[K, V]) {
     inner.aggregate(initializerJ, adderJ, subtractorJ)
   }
 
-  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
-    adder: (SK, SV, VR) => VR,
-    subtractor: (SK, SV, VR) => VR,
+  def aggregate[VR](initializer: () => VR,
+    adder: (K, V, VR) => VR,
+    subtractor: (K, V, VR) => VR,
     materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, VR] = {
 
     val initializerJ: Initializer[VR] = () => initializer()

--- a/src/main/scala/com/lightbend/kafka/scala/streams/SessionWindowedKStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/SessionWindowedKStreamS.scala
@@ -9,30 +9,30 @@ import ImplicitConversions._
 
 class SessionWindowedKStreamS[K, V](val inner: SessionWindowedKStream[K, V]) {
 
-  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
-    aggregator: (SK, SV, VR) => VR,
-    merger: (SK, VR, VR) => VR): KTableS[Windowed[K], VR] = {
+  def aggregate[VR](initializer: () => VR,
+    aggregator: (K, V, VR) => VR,
+    merger: (K, VR, VR) => VR): KTableS[Windowed[K], VR] = {
 
     val initializerJ: Initializer[VR] = () => initializer()
-    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
-    val mergerJ: Merger[SK, VR] = (k: SK, v1: VR, v2: VR) => merger(k, v1, v2)
+    val aggregatorJ: Aggregator[K, V, VR] = (k, v, va) => aggregator(k, v, va)
+    val mergerJ: Merger[K, VR] = (k, v1, v2) => merger(k, v1, v2)
     inner.aggregate(initializerJ, aggregatorJ, mergerJ)
   }
 
-  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
-    aggregator: (SK, SV, VR) => VR,
-    merger: (SK, VR, VR) => VR,
+  def aggregate[VR](initializer: () => VR,
+    aggregator: (K, V, VR) => VR,
+    merger: (K, VR, VR) => VR,
     materialized: Materialized[K, VR, SessionStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], VR] = {
 
     val initializerJ: Initializer[VR] = () => initializer()
-    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
-    val mergerJ: Merger[SK, VR] = (k: SK, v1: VR, v2: VR) => merger(k, v1, v2)
+    val aggregatorJ: Aggregator[K, V, VR] = (k, v, va) => aggregator(k, v, va)
+    val mergerJ: Merger[K, VR] = (k, v1, v2) => merger(k, v1, v2)
     inner.aggregate(initializerJ, aggregatorJ, mergerJ, materialized)
   }
 
   def count(): KTableS[Windowed[K], Long] = {
     val c: KTableS[Windowed[K], java.lang.Long] = inner.count()
-    c.mapValues[Long, java.lang.Long, Long](Long2long(_))
+    c.mapValues[Long](Long2long(_))
   }
 
   def count(materialized: Materialized[K, Long, SessionStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], Long] = 

--- a/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
@@ -11,7 +11,7 @@ import org.apache.kafka.streams.{Consumed, StreamsBuilder, Topology}
 
 import scala.collection.JavaConverters._
 
-object StreamsBuilderS {
+class StreamsBuilderS {
 
   val inner = new StreamsBuilder
 

--- a/src/main/scala/com/lightbend/kafka/scala/streams/TimeWindowedKStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/TimeWindowedKStreamS.scala
@@ -9,26 +9,26 @@ import ImplicitConversions._
 
 class TimeWindowedKStreamS[K, V](val inner: TimeWindowedKStream[K, V]) {
 
-  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
-    aggregator: (SK, SV, VR) => VR): KTableS[Windowed[K], VR] = {
+  def aggregate[VR](initializer: () => VR,
+    aggregator: (K, V, VR) => VR): KTableS[Windowed[K], VR] = {
 
     val initializerJ: Initializer[VR] = () => initializer()
-    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
+    val aggregatorJ: Aggregator[K, V, VR] = (k, v, va) => aggregator(k, v, va)
     inner.aggregate(initializerJ, aggregatorJ)
   }
 
-  def aggregate[VR, SK >: K, SV >: V](initializer: () => VR,
-    aggregator: (SK, SV, VR) => VR,
+  def aggregate[VR](initializer: () => VR,
+    aggregator: (K, V, VR) => VR,
     materialized: Materialized[K, VR, WindowStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], VR] = {
 
     val initializerJ: Initializer[VR] = () => initializer()
-    val aggregatorJ: Aggregator[K, V, VR] = (k: K, v: V, va: VR) => aggregator(k, v, va)
+    val aggregatorJ: Aggregator[K, V, VR] = (k, v, va) => aggregator(k, v, va)
     inner.aggregate(initializerJ, aggregatorJ, materialized)
   }
 
   def count(): KTableS[Windowed[K], Long] = {
     val c: KTableS[Windowed[K], java.lang.Long] = inner.count()
-    c.mapValues[Long, java.lang.Long, Long](Long2long(_))
+    c.mapValues[Long](Long2long(_))
   }
 
   def count(materialized: Materialized[K, Long, WindowStore[Bytes, Array[Byte]]]): KTableS[Windowed[K], Long] = 

--- a/src/test/scala/com/lightbend/kafka/scala/server/KafkaLocalServer.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/server/KafkaLocalServer.scala
@@ -1,0 +1,192 @@
+package com.lightbend.kafka.scala.server
+
+// Loosely based on Lagom implementation at
+//  https://github.com/lagom/lagom/blob/master/dev/kafka-server/src/main/scala/com/lightbend/lagom/internal/kafka/KafkaLocalServer.scala
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.FileVisitOption
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.Properties
+
+import org.apache.curator.test.TestingServer
+import org.slf4j.LoggerFactory
+
+import kafka.server.{KafkaConfig, KafkaServerStartable}
+
+import scala.collection.JavaConverters._
+import java.util.Comparator
+
+import kafka.admin.{AdminUtils, RackAwareMode}
+import kafka.utils.ZkUtils
+
+class KafkaLocalServer private (kafkaProperties: Properties, zooKeeperServer: ZooKeeperLocalServer) {
+
+  import KafkaLocalServer._
+
+  private var broker = null.asInstanceOf[KafkaServerStartable]
+  private var zkUtils : ZkUtils =
+    ZkUtils.apply(s"localhost:${zooKeeperServer.getPort()}", DEFAULT_ZK_SESSION_TIMEOUT_MS, DEFAULT_ZK_CONNECTION_TIMEOUT_MS, false)
+
+  def start(): Unit = {
+
+    broker = KafkaServerStartable.fromProps(kafkaProperties)
+    broker.startup()
+  }
+
+  def stop(): Unit = {
+    if (broker != null) {
+      broker.shutdown()
+      zooKeeperServer.stop()
+      broker = null.asInstanceOf[KafkaServerStartable]
+    }
+  }
+
+  /**
+    * Create a Kafka topic with 1 partition and a replication factor of 1.
+    *
+    * @param topic The name of the topic.
+    */
+  def createTopic(topic: String): Unit = {
+    createTopic(topic, 1, 1, new Properties)
+  }
+
+  /**
+    * Create a Kafka topic with the given parameters.
+    *
+    * @param topic       The name of the topic.
+    * @param partitions  The number of partitions for this topic.
+    * @param replication The replication factor for (the partitions of) this topic.
+    */
+  def createTopic(topic: String, partitions: Int, replication: Int): Unit = {
+    createTopic(topic, partitions, replication, new Properties)
+  }
+
+  /**
+    * Create a Kafka topic with the given parameters.
+    *
+    * @param topic       The name of the topic.
+    * @param partitions  The number of partitions for this topic.
+    * @param replication The replication factor for (partitions of) this topic.
+    * @param topicConfig Additional topic-level configuration settings.
+    */
+  def createTopic(topic: String, partitions: Int, replication: Int, topicConfig: Properties): Unit = {
+    AdminUtils.createTopic(zkUtils, topic, partitions, replication, topicConfig, RackAwareMode.Enforced)
+  }
+}
+
+object KafkaLocalServer {
+  final val DefaultPort = 9092
+  final val DefaultResetOnStart = true
+  private val DEFAULT_ZK_CONNECT = "localhost:2181"
+  private val DEFAULT_ZK_SESSION_TIMEOUT_MS = 10 * 1000
+  private val DEFAULT_ZK_CONNECTION_TIMEOUT_MS = 8 * 1000
+
+  private final val basDir = "tmp/"
+
+  private final val KafkaDataFolderName = "kafka_data"
+
+  val Log = LoggerFactory.getLogger(classOf[KafkaLocalServer])
+
+  def apply(cleanOnStart: Boolean): KafkaLocalServer = this(DefaultPort, ZooKeeperLocalServer.DefaultPort, cleanOnStart)
+
+  def apply(kafkaPort: Int, zookeeperServerPort: Int, cleanOnStart: Boolean): KafkaLocalServer = {
+    val kafkaDataDir = dataDirectory(KafkaDataFolderName)
+    Log.info(s"Kafka data directory is $kafkaDataDir.")
+
+    val kafkaProperties = createKafkaProperties(kafkaPort, zookeeperServerPort, kafkaDataDir)
+
+    if (cleanOnStart) deleteDirectory(kafkaDataDir)
+    val zk = new ZooKeeperLocalServer(zookeeperServerPort, cleanOnStart)
+    zk.start()
+    new KafkaLocalServer(kafkaProperties, zk)
+  }
+
+  /**
+    * Creates a Properties instance for Kafka customized with values passed in argument.
+    */
+  private def createKafkaProperties(kafkaPort: Int, zookeeperServerPort: Int, dataDir: File): Properties = {
+
+    // TODO: Probably should be externalized into properties. Was rushing this in     
+    val kafkaProperties = new Properties
+    kafkaProperties.put(KafkaConfig.ListenersProp, s"PLAINTEXT://localhost:$kafkaPort")
+    kafkaProperties.put(KafkaConfig.ZkConnectProp, s"localhost:$zookeeperServerPort")
+    kafkaProperties.put(KafkaConfig.ZkConnectionTimeoutMsProp, "6000")
+    kafkaProperties.put(KafkaConfig.BrokerIdProp, "0")
+    kafkaProperties.put(KafkaConfig.NumNetworkThreadsProp, "3")
+    kafkaProperties.put(KafkaConfig.NumIoThreadsProp, "8")
+    kafkaProperties.put(KafkaConfig.SocketSendBufferBytesProp, "102400")
+    kafkaProperties.put(KafkaConfig.SocketReceiveBufferBytesProp, "102400")
+    kafkaProperties.put(KafkaConfig.SocketRequestMaxBytesProp, "104857600")
+    kafkaProperties.put(KafkaConfig.NumPartitionsProp, "1")
+    kafkaProperties.put(KafkaConfig.NumRecoveryThreadsPerDataDirProp, "1")
+    kafkaProperties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
+    kafkaProperties.put(KafkaConfig.TransactionsTopicReplicationFactorProp, "1")
+    kafkaProperties.put(KafkaConfig.LogRetentionTimeHoursProp, "2")
+    kafkaProperties.put(KafkaConfig.LogSegmentBytesProp, "1073741824")
+    kafkaProperties.put(KafkaConfig.LogCleanupIntervalMsProp, "300000")
+    kafkaProperties.put(KafkaConfig.AutoCreateTopicsEnableProp, "true")
+    kafkaProperties.put(KafkaConfig.ControlledShutdownEnableProp, "true")
+    kafkaProperties.put(KafkaConfig.LogDirProp, dataDir.getAbsolutePath)
+
+    kafkaProperties
+  }
+
+  def deleteDirectory(directory: File): Unit = {
+    if (directory.exists()) try {
+      val rootPath = Paths.get(directory.getAbsolutePath)
+
+      val files = Files.walk(rootPath, FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).iterator().asScala
+      files.foreach(Files.delete)
+      Log.debug(s"Deleted ${directory.getAbsolutePath}.")
+    } catch {
+      case e: Exception => Log.warn(s"Failed to delete directory ${directory.getAbsolutePath}.", e)
+    }
+  }
+
+  def dataDirectory(directoryName: String): File = {
+
+    val dataDirectory = new File(basDir + directoryName)
+    if (dataDirectory.exists() && !dataDirectory.isDirectory())
+      throw new IllegalArgumentException(s"Cannot use $directoryName as a directory name because a file with that name already exists in $dataDirectory.")
+
+    dataDirectory
+  }
+}
+
+private class ZooKeeperLocalServer(port: Int, cleanOnStart: Boolean) {
+
+  import KafkaLocalServer._
+  import ZooKeeperLocalServer._
+
+  private var zooKeeper = null.asInstanceOf[TestingServer]
+
+  def start(): Unit = {
+    val zookeeperDataDir = dataDirectory(ZookeeperDataFolderName)
+    zooKeeper = new TestingServer(port, zookeeperDataDir, false)
+    Log.info(s"Zookeeper data directory is $zookeeperDataDir.")
+
+    if (cleanOnStart) deleteDirectory(zookeeperDataDir)
+
+    zooKeeper.start() // blocking operation
+  }
+
+  def stop(): Unit = {
+    if (zooKeeper != null)
+      try {
+        zooKeeper.stop()
+        zooKeeper = null.asInstanceOf[TestingServer]
+      }
+      catch {
+        case _: IOException => () // nothing to do if an exception is thrown while shutting down
+      }
+  }
+
+  def getPort() : Int = port
+}
+
+object ZooKeeperLocalServer {
+  final val DefaultPort = 2181
+  private final val ZookeeperDataFolderName = "zookeeper_data"
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
@@ -1,0 +1,20 @@
+package com.lightbend.kafka.scala.streams
+
+import minitest._
+import com.lightbend.kafka.scala.server.KafkaLocalServer
+
+
+object KafkaStreamsTest extends TestSuite[KafkaLocalServer] {
+  def setup(): KafkaLocalServer = {
+    KafkaLocalServer(true)
+  }
+
+  def tearDown(env: KafkaLocalServer): Unit = {
+    env.stop()
+  }
+
+  test("simple test") { env =>
+    assert(env != null)
+  }
+}
+


### PR DESCRIPTION
This PR puts this library in a (sort of) stable state. I have removed most of the type bounds from the Scala code because I realized that since we are exposing functions in the public API, the variance part is taken care of by the built-in variances of `FunctionX`. e.g. Consider the following Java API in `KStream<K, V>` ..

```
<VR> KStream<K,VR> mapValues(ValueMapper<? super V,? extends VR> mapper)
```
We publish the corresponding Scala API as ..

```
def mapValues[VR](V => VR): KStreamS[K, VR]
```
Since we are publishing `ValueMapper` as a `Function1`, we don't need to apply the type bounds, since `Function1[-T, +R]` takes care of the variances of input arguments and return types.

**Unit Tests**

This PR also puts the basic infrastructure in place for writing tests. Imported from Boris' code the `KafkaLocalServer` class which will be used as an embedded server for testing. Now need to write the tests though.