### PR TITLE
Type refinements, lots of changes, test infrastructure and more

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,10 +14,14 @@ libraryDependencies += "org.apache.kafka" % "kafka-streams" % "1.0.0"
 libraryDependencies += "org.slf4j" % "slf4j-log4j12" % "1.7.25"
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
 
-libraryDependencies += "org.apache.kafka" % "kafka_2.12" % "1.0.0" % "test"
+libraryDependencies += "org.apache.kafka" % "kafka_2.12" % "1.0.0" % "test" exclude("org.apache.zookeeper", "zookeeper")
 libraryDependencies += "org.apache.curator" % "curator-test" % "4.0.0" % "test"
 libraryDependencies += "io.monix" %% "minitest" % "2.0.0" % "test"
 libraryDependencies += "io.monix" %% "minitest-laws" % "2.0.0" % "test"
+
+libraryDependencies += "io.circe" %% "circe-core"    % "0.8.0" % "test"
+libraryDependencies += "io.circe" %% "circe-generic" % "0.8.0" % "test"
+libraryDependencies += "io.circe" %% "circe-parser"  % "0.8.0" % "test"
 
 testFrameworks += new TestFramework("minitest.runner.Framework")
 

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KStreamS.scala
@@ -61,7 +61,7 @@ class KStreamS[K, V](val inner: KStream[K, V]) {
 
   def branch(predicates: ((K, V) => Boolean)*): Array[KStreamS[K, V]] = {
     val predicatesJ = predicates.map(predicate => {
-        val predicateJ: Predicate[K, V] = (k, v) => predicate(k, v)
+      val predicateJ: Predicate[K, V] = (k, v) => predicate(k, v)
       predicateJ
     })
     inner.branch(predicatesJ: _*)

--- a/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
@@ -4,10 +4,11 @@ import java.util.regex.Pattern
 
 import ImplicitConversions._
 import org.apache.kafka.common.serialization.Serde
-import org.apache.kafka.streams.kstream.GlobalKTable
+import org.apache.kafka.streams.kstream.{ GlobalKTable, Materialized }
 import org.apache.kafka.streams.processor.{ProcessorSupplier, StateStore}
-import org.apache.kafka.streams.state.StoreBuilder
+import org.apache.kafka.streams.state.{ StoreBuilder, KeyValueStore }
 import org.apache.kafka.streams.{Consumed, StreamsBuilder, Topology}
+import org.apache.kafka.common.utils.Bytes
 
 import scala.collection.JavaConverters._
 
@@ -23,22 +24,21 @@ class StreamsBuilderS {
      inner.stream[K, V](topics.asJava, consumed)
   }
 
-  def stream[K, V](offsetReset: Topology.AutoOffsetReset,
-                   topics: String*) : KStreamS[K, V] =
-    inner.stream[K, V](topics.asJava, Consumed.`with`[K,V](offsetReset))
-
   def stream[K, V](topicPattern: Pattern) : KStreamS[K, V] =
     inner.stream[K, V](topicPattern)
 
-  def stream[K, V](offsetReset: Topology.AutoOffsetReset, topicPattern: Pattern): KStreamS[K, V] =
-    inner.stream[K, V](topicPattern, Consumed.`with`[K,V](offsetReset))
-
   def table[K, V](topic: String) : KTableS[K, V] = inner.table[K, V](topic)
 
-  def table[K, V](offsetReset: Topology.AutoOffsetReset,
-                  topic: String) : KTableS[K, V] =
-    inner.table[K, V](topic,  Consumed.`with`[K,V](offsetReset))
+  def table[K, V](topic: String, consumed: Consumed[K, V]) : KTableS[K, V] =
+    inner.table[K, V](topic, consumed)
 
+  def table[K, V](topic: String, consumed: Consumed[K, V],
+    materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, V] = 
+    inner.table[K, V](topic,  consumed, materialized)
+
+  def table[K, V](topic: String, 
+    materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, V] = 
+    inner.table[K, V](topic, materialized)
 
   def globalTable[K, V](topic: String): GlobalKTable[K, V] =
     inner.globalTable(topic)

--- a/src/test/scala/com/lightbend/kafka/scala/server/KafkaLocalServer.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/server/KafkaLocalServer.scala
@@ -74,6 +74,8 @@ class KafkaLocalServer private (kafkaProperties: Properties, zooKeeperServer: Zo
   def createTopic(topic: String, partitions: Int, replication: Int, topicConfig: Properties): Unit = {
     AdminUtils.createTopic(zkUtils, topic, partitions, replication, topicConfig, RackAwareMode.Enforced)
   }
+
+  def deleteTopic(topic: String) = AdminUtils.deleteTopic(zkUtils, topic)
 }
 
 object KafkaLocalServer {
@@ -141,7 +143,9 @@ object KafkaLocalServer {
       files.foreach(Files.delete)
       Log.debug(s"Deleted ${directory.getAbsolutePath}.")
     } catch {
-      case e: Exception => Log.warn(s"Failed to delete directory ${directory.getAbsolutePath}.", e)
+      case e: Exception => { 
+        Log.warn(s"Failed to delete directory ${directory.getAbsolutePath}.", e)
+      }
     }
   }
 

--- a/src/test/scala/com/lightbend/kafka/scala/server/MessageListener.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/server/MessageListener.scala
@@ -1,0 +1,85 @@
+package com.lightbend.kafka.scala.server
+
+import org.apache.kafka.clients.consumer.{ ConsumerConfig, KafkaConsumer }
+import org.apache.kafka.streams.KeyValue
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+
+
+object MessageListener {
+  private val AUTOCOMMITINTERVAL = "1000" // Frequency of offset commits
+  private val SESSIONTIMEOUT = "30000" // The timeout used to detect failures - should be greater then processing time
+  private val MAXPOLLRECORDS = "50" // Max number of records consumed in a single poll
+
+  def consumerProperties(brokers: String, group: String, keyDeserializer: String, valueDeserializer: String): Map[String, AnyRef] = {
+    Map[String, AnyRef](
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> brokers,
+      ConsumerConfig.GROUP_ID_CONFIG -> group,
+      ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> "true",
+      ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG -> AUTOCOMMITINTERVAL,
+      ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG -> SESSIONTIMEOUT,
+      ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> MAXPOLLRECORDS,
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "latest",
+      ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG -> keyDeserializer,
+      ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> valueDeserializer
+    )
+  }
+
+  def apply[K, V](brokers: String, topic: String, group: String, keyDeserializer: String, valueDeserializer: String,
+                  processor: RecordProcessorTrait[K, V]): MessageListener[K, V] =
+    new MessageListener[K, V](brokers, topic, group, keyDeserializer, valueDeserializer, processor)
+}
+
+class MessageListener[K, V](
+  brokers: String, 
+  topic: String, 
+  group: String, 
+  keyDeserializer: String, 
+  valueDeserializer: String,
+  processor: RecordProcessorTrait[K, V]) {
+
+  import MessageListener._
+
+  def readKeyValues(maxMessages: Int): List[KeyValue[K, V]] = {
+    val pollIntervalMs = 100
+    val maxTotalPollTimeMs = 2000
+    var totalPollTimeMs = 0
+
+    val consumer = new KafkaConsumer[K, V](consumerProperties(brokers, group, keyDeserializer, valueDeserializer).asJava)
+    consumer.subscribe(Seq(topic).asJava)
+
+    val consumedValues = ListBuffer.empty[KeyValue[K, V]]
+
+    while (totalPollTimeMs < maxTotalPollTimeMs && continueConsuming(consumedValues.size, maxMessages)) {
+      totalPollTimeMs = totalPollTimeMs + pollIntervalMs
+      val records = consumer.poll(pollIntervalMs)
+      records.asScala.foreach { record => 
+        processor.processRecord(record)
+        consumedValues += new KeyValue(record.key, record.value)
+      }
+    }
+    consumer.close()
+    consumedValues.toList
+  }
+
+  def continueConsuming(messagesConsumed: Int, maxMessages: Int): Boolean = {
+    maxMessages <= 0 || messagesConsumed < maxMessages
+  }
+
+  def waitUntilMinKeyValueRecordsReceived(expectedNumRecords: Int, waitTime: Long, 
+    startTime: Long = System.currentTimeMillis(), 
+    accumData: ListBuffer[KeyValue[K, V]] = ListBuffer.empty[KeyValue[K, V]]): List[KeyValue[K, V]] = {
+
+    val readData = readKeyValues(-1)
+    accumData ++= readData
+
+    if (accumData.size >= expectedNumRecords) accumData.toList
+    else if (System.currentTimeMillis() > startTime + waitTime) {
+      throw new AssertionError(
+        s"Expected $expectedNumRecords but received only ${accumData.size} records before timeout $waitTime ms")
+    } else {
+      Thread.sleep(Math.min(waitTime, 1000L))
+      waitUntilMinKeyValueRecordsReceived(expectedNumRecords, waitTime, startTime, accumData)
+    }
+  }
+}

--- a/src/test/scala/com/lightbend/kafka/scala/server/MessageSender.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/server/MessageSender.scala
@@ -1,0 +1,55 @@
+package com.lightbend.kafka.scala.server
+
+import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata }
+import java.util.Properties
+
+object MessageSender {
+  private val ACKCONFIGURATION = "all" // Blocking on the full commit of the record
+  private val RETRYCOUNT = "1" // Number of retries on put
+  private val BATCHSIZE = "1024" // Buffers for unsent records for each partition - controlls batching
+  private val LINGERTIME = "1" // Timeout for more records to arive - controlls batching
+  private val BUFFERMEMORY = "1024000" // Controls the total amount of memory available to the producer for buffering. If records are sent faster than they can be transmitted to the server then this buffer space will be exhausted. When the buffer space is exhausted additional send calls will block. The threshold for time to block is determined by max.block.ms after which it throws a TimeoutException.
+
+  def providerProperties(brokers: String, keySerializer: String, valueSerializer: String): Properties = {
+    val props = new Properties
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+    props.put(ProducerConfig.ACKS_CONFIG, ACKCONFIGURATION)
+    props.put(ProducerConfig.RETRIES_CONFIG, RETRYCOUNT)
+    props.put(ProducerConfig.BATCH_SIZE_CONFIG, BATCHSIZE)
+    props.put(ProducerConfig.LINGER_MS_CONFIG, LINGERTIME)
+    props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, BUFFERMEMORY)
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer)
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer)
+    props
+  }
+
+  def apply[K, V](brokers: String, keySerializer: String, valueSerializer: String): MessageSender[K, V] =
+    new MessageSender[K, V](brokers, keySerializer, valueSerializer)
+}
+
+class MessageSender[K, V](val brokers: String, val keySerializer: String, val valueSerializer: String) {
+
+  import MessageSender._
+  val producer = new KafkaProducer[K, V](providerProperties(brokers, keySerializer, valueSerializer))
+
+  def writeKeyValue(topic: String, key: K, value: V): Unit = {
+    val result = producer.send(new ProducerRecord[K, V](topic, key, value)).get
+    producer.flush()
+  }
+
+  def writeValue(topic: String, value: V): Unit = {
+    val result = producer.send(new ProducerRecord[K, V](topic, null.asInstanceOf[K], value)).get
+    producer.flush()
+  }
+
+  def batchWriteValue(topic: String, batch: Seq[V]): Seq[RecordMetadata] = {
+    val result = batch.map(value => {
+      producer.send(new ProducerRecord[K, V](topic, null.asInstanceOf[K], value)).get})
+    producer.flush()
+    result
+  }
+
+  def close(): Unit = {
+    producer.close()
+  }
+}

--- a/src/test/scala/com/lightbend/kafka/scala/server/RecordProcessorTrait.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/server/RecordProcessorTrait.scala
@@ -1,0 +1,9 @@
+package com.lightbend.kafka.scala.server
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+// A trait, that should be implemented by any listener implementation
+
+trait RecordProcessorTrait[K, V] {
+  def processRecord(record: ConsumerRecord[K, V]): Unit
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
@@ -1,20 +1,125 @@
 package com.lightbend.kafka.scala.streams
 
-import minitest._
-import com.lightbend.kafka.scala.server.KafkaLocalServer
+import minitest.TestSuite
+import com.lightbend.kafka.scala.server.{ KafkaLocalServer, MessageSender, MessageListener, RecordProcessorTrait }
 
+import java.util.{ Properties, Locale }
+import java.util.regex.Pattern
 
-object KafkaStreamsTest extends TestSuite[KafkaLocalServer] {
-  def setup(): KafkaLocalServer = {
-    KafkaLocalServer(true)
+import org.apache.kafka.streams.{ KeyValue, StreamsConfig, KafkaStreams, Consumed }
+import org.apache.kafka.streams.kstream.{ Materialized, Produced, KeyValueMapper, Printed }
+import org.apache.kafka.common.serialization.{ Serdes, StringSerializer, StringDeserializer }
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+import scala.concurrent.duration._
+import com.lightbend.kafka.scala.util.{ Serializers, ScalaLongSerializer }
+
+import ImplicitConversions._
+
+object KafkaStreamsTest extends TestSuite[KafkaLocalServer] with Serializers with WordCountTestData {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true)
+    s.start()
+    s
   }
 
-  def tearDown(env: KafkaLocalServer): Unit = {
-    env.stop()
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
   }
 
-  test("simple test") { env =>
-    assert(env != null)
+  test("should count words") { server =>
+
+    server.createTopic(inputTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val stringSerde = Serdes.String()
+
+    val streamsConfiguration = new Properties()
+    streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, s"wordcount-${scala.util.Random.nextInt(100)}")
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "wordcountgroup")
+    
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+    streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName())
+    streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName())
+
+    val builder = new StreamsBuilderS
+
+    val textLines = builder.stream[String, String](inputTopic)
+
+    val pattern = Pattern.compile("\\W+", Pattern.UNICODE_CHARACTER_CLASS)
+
+    val wordCounts: KTableS[String, Long] = 
+      textLines.flatMapValues(v => pattern.split(v.toLowerCase))
+        .map { (_, value) => (value, value) }
+        .groupBy((k, v) => v)
+        .count()
+
+    wordCounts.toStream.to(outputTopic, Produced.`with`(stringSerde, scalaLongSerde))
+
+    val streams = new KafkaStreams(builder.build, streamsConfiguration)
+    streams.start()
+
+    //
+    // Step 2: Produce some input data to the input topic.
+    //
+    val sender = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName) 
+    val mvals = sender.batchWriteValue(inputTopic, inputValues)
+
+    //
+    // Step 3: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "wordcountgroup", 
+      classOf[StringDeserializer].getName, 
+      classOf[ScalaLongSerializer].getName, 
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedWordCounts.size, 30000)
+
+    assertEquals(l.sortBy(_.key), expectedWordCounts.sortBy(_.key))
+
+    streams.close()
   }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = { 
+      // println(s"Get Message $record")
+    }
+  }
+}
+
+trait WordCountTestData {
+  val inputTopic = "inputTopic"
+  val outputTopic = "outputTopic"
+  val brokers = "localhost:9092"
+
+  val inputValues = List(
+    "Hello Kafka Streams",
+    "All streams lead to Kafka",
+    "Join Kafka Summit",
+    "И теперь пошли русские слова"
+  )
+
+  val expectedWordCounts: List[KeyValue[String, Long]] = List(
+    new KeyValue("hello", 1L),
+    new KeyValue("all", 1L),
+    new KeyValue("streams", 2L),
+    new KeyValue("lead", 1L),
+    new KeyValue("to", 1L),
+    new KeyValue("join", 1L),
+    new KeyValue("kafka", 3L),
+    new KeyValue("summit", 1L),
+    new KeyValue("и", 1L),
+    new KeyValue("теперь", 1L),
+    new KeyValue("пошли", 1L),
+    new KeyValue("русские", 1L),
+    new KeyValue("слова", 1L)
+  )
 }
 

--- a/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTest.scala
@@ -1,0 +1,193 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams
+
+import java.util.Properties
+import minitest.TestSuite
+import com.lightbend.kafka.scala.server.{ KafkaLocalServer, MessageSender, MessageListener, RecordProcessorTrait }
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams.kstream._
+import org.apache.kafka.streams._
+
+import com.lightbend.kafka.scala.util.{ ScalaLongSerializer, Serializers }
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import collection.JavaConverters._
+import ImplicitConversions._
+
+/**
+  * End-to-end integration test that demonstrates how to perform a join between a KStream and a
+  * KTable (think: KStream.leftJoin(KTable)), i.e. an example of a stateful computation.
+  *
+  * See StreamToTableJoinIntegrationTest for the equivalent Java example.
+  *
+  * Note: We intentionally use JUnit4 (wrapped by ScalaTest) for implementing this Scala integration
+  * test so it is easier to compare this Scala code with the equivalent Java code at
+  * StreamToTableJoinIntegrationTest.  One difference is that, to simplify the Scala/Junit integration, we
+  * switched from BeforeClass (which must be `static`) to Before as well as from @ClassRule (which
+  * must be `static` and `public`) to a workaround combination of `@Rule def` and a `private val`.
+  */
+
+object StreamToTableJoinScalaIntegrationTest extends TestSuite[KafkaLocalServer] with StreamToTableJoinTestData with Serializers {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true)
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count clicks per region") { server =>
+
+    server.createTopic(userClicksTopic)
+    server.createTopic(userRegionsTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val stringSerde: Serde[String] = Serdes.String()
+
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p.put(StreamsConfig.APPLICATION_ID_CONFIG, s"stream-table-join-scala-integration-test-${scala.util.Random.nextInt(100)}")
+      p.put(StreamsConfig.CLIENT_ID_CONFIG, "join-scala-integration-test-standard-consumer")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, "local_state_data")
+      p
+    }
+
+    val builder = new StreamsBuilderS
+
+    val userClicksStream: KStreamS[String, Long] = builder.stream(List(userClicksTopic), Consumed.`with`(stringSerde, scalaLongSerde))
+
+    val userRegionsTable: KTableS[String, String] = builder.table(userRegionsTopic, Consumed.`with`(stringSerde, stringSerde))
+
+    // Compute the total per region by summing the individual click counts per region.
+    val clicksPerRegion: KTableS[String, Long] = 
+      userClicksStream
+
+        // Join the stream against the table.
+        .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
+
+        // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+        .map((_: String, regionWithClicks: (String, Long)) => regionWithClicks)
+
+        // Compute the total per region by summing the individual click counts per region.
+        .groupByKey(Serialized.`with`(stringSerde, scalaLongSerde))
+        .reduce(_ + _)
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic, Produced.`with`(stringSerde, scalaLongSerde))
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build, streamsConfiguration)
+
+    streams.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      override def uncaughtException(t: Thread, e: Throwable): Unit = try {
+        println(s"Stream terminated because of uncaught exception .. Shutting down app", e)
+        e.printStackTrace
+        val closed = streams.close()
+        println(s"Exiting application after streams close ($closed)")
+      } catch {
+        case x: Exception => x.printStackTrace
+      } finally {
+        println("Exiting application ..")
+        System.exit(-1)
+      }
+    })
+
+    streams.start()
+
+    //
+    // Step 2: Publish user-region information.
+    //
+    // To keep this code example simple and easier to understand/reason about, we publish all
+    // user-region records before any user-click records (cf. step 3).  In practice though,
+    // data records would typically be arriving concurrently in both input streams/topics.
+    val sender1 = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName) 
+    userRegions.foreach(r => sender1.writeKeyValue(userRegionsTopic, r.key, r.value))
+
+    //
+    // Step 3: Publish some user click events.
+    //
+    val sender2 = MessageSender[String, Long](brokers, classOf[StringSerializer].getName, classOf[ScalaLongSerializer].getName) 
+    userClicks.foreach(r => sender2.writeKeyValue(userClicksTopic, r.key, r.value))
+
+    //
+    // Step 4: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "join-scala-integration-test-standard-consumer", 
+      classOf[StringDeserializer].getName, 
+      classOf[ScalaLongSerializer].getName, 
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedClicksPerRegion.size, 30000)
+    streams.close()
+    assertEquals(l.sortBy(_.key), expectedClicksPerRegion.sortBy(_.key))
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = { 
+      // println(s"Get Message $record")
+    }
+  }
+}
+
+trait StreamToTableJoinTestData {
+  val brokers = "localhost:9092"
+
+  val userClicksTopic = "user-clicks"
+  val userRegionsTopic = "user-regions"
+  val outputTopic = "output-topic"
+
+  // Input 1: Clicks per user (multiple records allowed per user).
+  val userClicks: Seq[KeyValue[String, Long]] = Seq(
+    new KeyValue("alice", 13L),
+    new KeyValue("bob", 4L),
+    new KeyValue("chao", 25L),
+    new KeyValue("bob", 19L),
+    new KeyValue("dave", 56L),
+    new KeyValue("eve", 78L),
+    new KeyValue("alice", 40L),
+    new KeyValue("fang", 99L)
+  )
+
+  // Input 2: Region per user (multiple records allowed per user).
+  val userRegions: Seq[KeyValue[String, String]] = Seq(
+    new KeyValue("alice", "asia"), /* Alice lived in Asia originally... */
+    new KeyValue("bob", "americas"),
+    new KeyValue("chao", "asia"),
+    new KeyValue("dave", "europe"),
+    new KeyValue("alice", "europe"), /* ...but moved to Europe some time later. */
+    new KeyValue("eve", "americas"),
+    new KeyValue("fang", "asia")
+  )
+
+  val expectedClicksPerRegion: Seq[KeyValue[String, Long]] = Seq(
+    new KeyValue("americas", 101L),
+    new KeyValue("europe", 109L),
+    new KeyValue("asia", 124L)
+  )
+}

--- a/src/test/scala/com/lightbend/kafka/scala/util/ScalaLongSerializer.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/util/ScalaLongSerializer.scala
@@ -1,0 +1,31 @@
+package com.lightbend.kafka.scala.util
+
+import org.apache.kafka.common.serialization.{ Deserializer, Serializer }
+
+import java.nio.charset.Charset
+
+import io.circe._, io.circe.generic.auto._, io.circe.parser._, io.circe.syntax._
+
+class ScalaLongSerializer extends Serializer[Long] with Deserializer[Long] {
+
+  final val CHARSET = Charset.forName("UTF-8")
+
+  override def configure(configs: java.util.Map[String, _], isKey: Boolean) = {}
+
+  override def serialize(topic: String, data: Long) =
+    data.asJson.noSpaces.getBytes(CHARSET)
+
+  override def deserialize(topic: String, bytes: Array[Byte]) = {
+    if (bytes == null) 0L
+    else {
+      decode[Long](new String(bytes, CHARSET)) match {
+        case Right(t) => t
+        case Left(err) => throw new IllegalArgumentException(err.toString)
+      }
+    }
+  }
+
+  override def close() = {}
+}
+
+

--- a/src/test/scala/com/lightbend/kafka/scala/util/Serializers.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/util/Serializers.scala
@@ -1,0 +1,8 @@
+package com.lightbend.kafka.scala.util
+
+import org.apache.kafka.common.serialization.Serdes
+
+trait Serializers {
+  final val sls = new ScalaLongSerializer
+  final val scalaLongSerde = Serdes.serdeFrom(sls, sls)
+}


### PR DESCRIPTION
This PR does the following:

1. lots of type refinements
2. refactoring
3. test infrastructure incorporated
4. started writing tests - same ones from confluent examples

Now we have better type inference and hence better chaining of builder methods .. The following fragment is the replacement from https://github.com/confluentinc/kafka-streams-examples/blob/4.0.x/src/test/scala/io/confluent/examples/streams/StreamToTableJoinScalaIntegrationTest.scala#L144-L166

```scala
// Compute the total per region by summing the individual click counts per region.
val clicksPerRegion: KTableS[String, Long] = userClicksStream

  // Join the stream against the table.
  .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))

  // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
  .map((_: String, regionWithClicks: (String, Long)) => regionWithClicks)

  // Compute the total per region by summing the individual click counts per region.
  .groupByKey(Serialized.`with`(stringSerde, scalaLongSerde))
  .reduce(_ + _)
```

Now need to port more tests from Confluent examples and check for exhaustivity of the APIs. Also need to document stuff.