### PR TITLE
Tests need to run in sequence, minor refactoring in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,9 @@ crossScalaVersions := Seq("2.12.4", "2.11.11")
 
 scalacOptions := Seq("-Xexperimental", "-unchecked", "-deprecation")
 
-libraryDependencies += "org.apache.kafka" % "kafka-streams" % "1.0.0"
+parallelExecution in Test := false
+
+libraryDependencies += "org.apache.kafka" % "kafka-streams" % "1.0.0" exclude("org.apache.zookeeper", "zookeeper")
 libraryDependencies += "org.slf4j" % "slf4j-log4j12" % "1.7.25"
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
 

--- a/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
@@ -56,7 +56,6 @@ object KafkaStreamsTest extends TestSuite[KafkaLocalServer] with Serializers wit
 
     val wordCounts: KTableS[String, Long] = 
       textLines.flatMapValues(v => pattern.split(v.toLowerCase))
-        .map { (_, value) => (value, value) }
         .groupBy((k, v) => v)
         .count()
 

--- a/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTest.scala
@@ -92,7 +92,7 @@ object StreamToTableJoinScalaIntegrationTest extends TestSuite[KafkaLocalServer]
         .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
 
         // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
-        .map((_: String, regionWithClicks: (String, Long)) => regionWithClicks)
+        .map((_, regionWithClicks) => regionWithClicks)
 
         // Compute the total per region by summing the individual click counts per region.
         .groupByKey(Serialized.`with`(stringSerde, scalaLongSerde))


### PR DESCRIPTION
This is a small PR but does an important fix. The tests, if run in parallel, will error out since multiple ZK cannot be run in parallel. Changed build to enforce this.

Also did minor refactoring of tests.