### PR TITLE
API Refactoring 

### DIFF
--- a/kafka-stream-q-example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/WeblogProcessing.scala
+++ b/kafka-stream-q-example-dsl/src/main/scala/com/lightbend/kafka/scala/iq/example/WeblogProcessing.scala
@@ -208,12 +208,11 @@ object WeblogProcessing extends WeblogWorkflow {
     // for a host will be the correct one - all earlier records will be considered out of date
     //
     // materialize the summarized information into a topic
-    // groupedStream.count(Materialized.as(ACCESS_COUNT_PER_HOST_STORE)
-    groupedStream.count(ACCESS_COUNT_PER_HOST_STORE, stringSerde)
+    groupedStream.count(ACCESS_COUNT_PER_HOST_STORE, Some(stringSerde))
       .toStream.to(config.summaryAccessTopic.get, Produced.`with`(stringSerde, longSerde))
 
     groupedStream.windowedBy(TimeWindows.of(60000))
-      .count(WINDOWED_ACCESS_COUNT_PER_HOST_STORE, stringSerde)
+      .count(WINDOWED_ACCESS_COUNT_PER_HOST_STORE, Some(stringSerde))
       .toStream.to(config.windowedSummaryAccessTopic.get, Produced.`with`(windowedStringSerde, longSerde))
 
     // print the topic info (for debugging)

--- a/kafka-stream-s/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
+++ b/kafka-stream-s/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
@@ -14,8 +14,12 @@ class KGroupedStreamS[K, V](inner: KGroupedStream[K, V]) {
     c.mapValues[Long](Long2long(_))
   }
 
-  def count(store: String, keySerde: Serde[K]): KTableS[K, Long] = { 
-    val materialized = Materialized.as[K, java.lang.Long, KeyValueStore[Bytes, Array[Byte]]](store).withKeySerde(keySerde)
+  def count(store: String, keySerde: Option[Serde[K]] = None): KTableS[K, Long] = { 
+    val materialized = keySerde.map(k =>
+      Materialized.as[K, java.lang.Long, KeyValueStore[Bytes, Array[Byte]]](store).withKeySerde(k)
+    ).getOrElse(
+      Materialized.as[K, java.lang.Long, KeyValueStore[Bytes, Array[Byte]]](store)
+    )
 
     val c: KTableS[K, java.lang.Long] = inner.count(materialized)
     c.mapValues[Long](Long2long(_))

--- a/kafka-stream-s/src/main/scala/com/lightbend/kafka/scala/streams/TimeWindowedKStreamS.scala
+++ b/kafka-stream-s/src/main/scala/com/lightbend/kafka/scala/streams/TimeWindowedKStreamS.scala
@@ -31,8 +31,12 @@ class TimeWindowedKStreamS[K, V](val inner: TimeWindowedKStream[K, V]) {
     c.mapValues[Long](Long2long(_))
   }
 
-  def count(store: String, keySerde: Serde[K]): KTableS[Windowed[K], Long] = { 
-    val materialized = Materialized.as[K, java.lang.Long, WindowStore[Bytes, Array[Byte]]](store).withKeySerde(keySerde)
+  def count(store: String, keySerde: Option[Serde[K]] = None): KTableS[Windowed[K], Long] = { 
+    val materialized = keySerde.map(k =>
+      Materialized.as[K, java.lang.Long, WindowStore[Bytes, Array[Byte]]](store).withKeySerde(k)
+    ).getOrElse(
+      Materialized.as[K, java.lang.Long, WindowStore[Bytes, Array[Byte]]](store)
+    )
 
     val c: KTableS[Windowed[K], java.lang.Long] = inner.count(materialized)
     c.mapValues[Long](Long2long(_))


### PR DESCRIPTION
The `keySerde` argument in `KGroupedStreamS#count` and `TimeWindowedKStreamS#count` need to be optional since the user can also query using just the store name.