### PR TITLE
Added notes about cross version building.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,10 @@ This repository contains the following:
 2. [An http layer for Kafka Streams Interactive Queries](https://github.com/lightbend/kafka-streams-scala/blob/develop/kafka-stream-q/README.md): This is a utility that's quite useful for developing global queries across local states in a Kafka Streams application. More useful when the application is deployed in a distributed manner across multiple nodes.
 3. [An example application](https://github.com/lightbend/kafka-streams-scala/blob/develop/kafka-stream-q-example-dsl/README.md) based on Kafka Streams DSL that uses the library in (2).
 
-These tools support Kafka 1.0.0.
+These tools support Kafka 1.0.0. By default, they build for Scala 2.12 (with Scala 2.12.4), but you can build targets for both 2.12 and 2.11 (using Scala 2.11.11) in SBT by adding a plus, `+`, before each command. For example:
+
+```
+$ sbt
+> +clean
+> +publishLocal
+```


### PR DESCRIPTION
Minor addition to the top-level README, pointing out how to cross build for Scala 2.11 and 2.12.