### PR TITLE
The proc example application now runs with local Kafka Server

### DIFF
--- a/kafka-stream-q-example-dsl/README.md
+++ b/kafka-stream-q-example-dsl/README.md
@@ -83,7 +83,7 @@ $ curl http://localhost:7070/weblog/bytes/world.std.com
 
 The http query layer is designed to work even when your application runs in the distributed mode. Running your Kafka Streams application in the distributed mode means that all the instances must have the same application id.
 
-> In order to run the application in distributed mode, you need to run an external Kafka and Zookeeper server. Set `kafka.localserver` to `false` to enbale this setting.
+> In order to run the application in distributed mode, you need to run an external Kafka and Zookeeper server. Set `kafka.localserver` to `false` to enable this setting.
 
 Here are the steps that you need to follow to run the application in distributed mode. We assume here you are running both the instances in the same node with different port numbers. It's fairly easy to scale this on different nodes.
 

--- a/kafka-stream-q-example-proc/README.md
+++ b/kafka-stream-q-example-proc/README.md
@@ -12,6 +12,8 @@ The implementation is based on the [ClarkNet dataset](http://ita.ee.lbl.gov/html
 
 ## Build and Run Locally
 
+By default the application runs through an embedded local Kafka Server. In case you want to run separate instances of Kafka and Zookeeper servers, change `kafka.localserver` to `false` in `application.conf`.
+
 To run the application, do the following steps.
 
 ### Build the Libraries
@@ -19,6 +21,8 @@ To run the application, do the following steps.
 You'll need to build the Scala API library, `kafka-scala-s`, and the interactive queries library, `kafka-scala-q`. Change to each of those directories and run the SBT command `sbt publishLocal`, which compiles the code, creates archives, and "publishes" them to your local _ivy2_ repository. Note that Scala 2.12.4 and Kafka 1.0.0 are used.
 
 ### Start ZooKeeper and Kafka
+
+> This is only required if the setting of `kafka.localserver` is `false` in `application.conf`. If this is set to `true`, the application runs with an embedded local Kafka server. However, note that if you want to run the application in a distributed mode(see below for details of running in distributed mode), you need to run a separate Kafka and Zookeeper server.
 
 Start ZooKeeper and Kafka, if not already running. You can download Kafka 1.0.0 for Scala 2.12 [here](https://kafka.apache.org/documentation/#quickstart), then follow the [Quick Start](https://kafka.apache.org/documentation/#quickstart) instructions for running ZooKeeper and Kafka, steps 1 and 2.
 
@@ -32,7 +36,11 @@ Copy `src/main/resources/application-proc.conf.template` to  `src/main/resources
 
 Edit `src/main/resources/application-proc.conf` and set the entry for `directorytowatch` to match the folder name where you installed the ClarkNet dataset.
 
+And note that you can run the application with a bundled local Kafka server by setting `kafka.localserver` to `true` in the `application.conf` file.
+
 ### Create the Kafka Topics
+
+> This is only required if the setting of `kafka.localserver` is `false` in `application.conf`. If this is set to `true`, the application runs with an embedded local Kafka server and creates all necessary topics on its own. However, note that if you want to run the application in a distributed mode(see below for details of running in distributed mode), you need to run a separate Kafka and Zookeeper server.
 
 Create the topics using the `kafka-topics.sh` command that comes with the Kafka distribution. We'll refer to the directory where you installed Kafka as `$KAFKA_HOME`. Run the following commands:
 
@@ -70,6 +78,8 @@ false
 ## Run in Distributed Mode
 
 The http query layer is designed to work even when your application runs in the distributed mode. Running your Kafka Streams application in the distributed mode means that all the instances must have the same application id.
+
+> In order to run the application in distributed mode, you need to run an external Kafka and Zookeeper server. Set `kafka.localserver` to `false` to enable this setting.
 
 Here are the steps that you need to follow to run the application in distributed mode. We assume here you are running both the instances in the same node with different port numbers. It's fairly easy to scale this on different nodes.
 

--- a/kafka-stream-q-example-proc/build.sbt
+++ b/kafka-stream-q-example-proc/build.sbt
@@ -34,7 +34,9 @@ lazy val app = appProject("app")(".")
       circeGeneric,
       circeParser,
       logback,
-      scalaLogging
+      scalaLogging,
+      curator,
+      kafka
     ),
     scalacOptions ++= Seq(
       "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
@@ -103,7 +105,8 @@ lazy val procRun = project
     resourceDirectory in Compile := (resourceDirectory in (app, Compile)).value,
     javaOptions in run ++= Seq(
       "-Dconfig.file=" + (resourceDirectory in Compile).value / "application-proc.conf",
-      "-Dlogback.configurationFile=" + (resourceDirectory in Compile).value / "logback-proc.xml"),
+      "-Dlogback.configurationFile=" + (resourceDirectory in Compile).value / "logback-proc.xml",
+      "-Dlog4j.configurationFile=" + (resourceDirectory in Compile).value / "log4j.properties"),
     addCommandAlias("proc", "procRun/run")
   )
   .dependsOn(app)
@@ -114,7 +117,8 @@ lazy val procPackage = appProject("procPackage")("build/proc")
     resourceDirectory in Compile := (resourceDirectory in (app, Compile)).value,
     mappings in Universal ++= {
       Seq(((resourceDirectory in Compile).value / "application-proc.conf") -> "conf/application.conf") ++
-        Seq(((resourceDirectory in Compile).value / "logback-proc.xml") -> "conf/logback.xml")
+        Seq(((resourceDirectory in Compile).value / "logback-proc.xml") -> "conf/logback.xml") ++
+        Seq(((resourceDirectory in Compile).value / "log4j.properties") -> "conf/log4j.properties")
     },
     scriptClasspath := Seq("../conf/") ++ scriptClasspath.value,
     mainClass in Compile := Some("com.lightbend.kafka.scala.iq.example.WeblogDriver")

--- a/kafka-stream-q-example-proc/project/Dependencies.scala
+++ b/kafka-stream-q-example-proc/project/Dependencies.scala
@@ -20,4 +20,6 @@ object Dependencies {
   val circeParser     = "io.circe"                     %% "circe-parser"             % circeVersion
   val logback         = "ch.qos.logback"                % "logback-classic"          % logbackVersion
   val scalaLogging    = "com.typesafe.scala-logging"   %% "scala-logging"            % scalaLoggingVersion
+  val curator         = "org.apache.curator"            % "curator-test"             % curatorVersion
+  val kafka           = "org.apache.kafka"             %% "kafka"                    % kafkaVersion excludeAll(ExclusionRule("org.slf4j", "slf4j-log4j12"), ExclusionRule("org.apache.zookeeper", "zookeeper")) 
 }

--- a/kafka-stream-q-example-proc/project/Versions.scala
+++ b/kafka-stream-q-example-proc/project/Versions.scala
@@ -15,5 +15,7 @@ object Versions {
   val circeVersion = "0.8.0"
   val scalaLoggingVersion = "3.5.0"
   val logbackVersion = "1.2.3"  
+  val curatorVersion = "4.0.0"
+  val kafkaVersion = "1.0.0"
 }
 

--- a/kafka-stream-q-example-proc/src/main/resources/application-proc.conf.template
+++ b/kafka-stream-q-example-proc/src/main/resources/application-proc.conf.template
@@ -6,54 +6,53 @@ akka {
   event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
 }
 
-dcos {
+kafka {
+  # true if use local kafka server
+  # false otherwise
+  # if true, then setting of brokers below is ignored and set to that of KafkaLocalServer
+  localserver = true
 
-  kafka {
-    ## bootstrap servers for Kafka
-    brokers = "localhost:9092"
-    brokers = ${?KAFKA_BROKERS}
+  ## bootstrap servers for Kafka
+  brokers = "localhost:9092"
+  brokers = ${?KAFKA_BROKERS}
 
-    ## consumer group
-    group = "group-proc"
-    group = ${?KAFKA_GROUP_PROC}
+  ## consumer group
+  group = "group-proc"
+  group = ${?KAFKA_GROUP_PROC}
 
-    ## the source topic - processing starts with
-    ## data in this topic (to be loaded by ingestion)
-    fromtopic = "server-log-proc"
-    fromtopic = ${?KAFKA_FROM_TOPIC_PROC}
+  ## the source topic - processing starts with
+  ## data in this topic (to be loaded by ingestion)
+  fromtopic = "server-log-proc"
+  fromtopic = ${?KAFKA_FROM_TOPIC_PROC}
 
-    ## error topic for the initial processing
-    errortopic = "logerr-proc"
-    errortopic = ${?KAFKA_ERROR_TOPIC_PROC}
+  ## error topic for the initial processing
+  errortopic = "logerr-proc"
+  errortopic = ${?KAFKA_ERROR_TOPIC_PROC}
 
-    zookeeper = "localhost:2181"
-    zookeeper = ${?ZOOKEEPER_URL}
+  ## folder where state stores are created by Kafka Streams
+  statestoredir = "/tmp/kafka-streams"
+  statestoredir = ${?STATESTOREDIR}
 
-    ## folder where state stores are created by Kafka Streams
-    statestoredir = "/tmp/kafka-streams"
-    statestoredir = ${?STATESTOREDIR}
+  ## settings for data ingestion
+  loader {
+    sourcetopic = ${kafka.fromtopic}
+    sourcetopic = ${?KAFKA_FROM_TOPIC_PROC}
 
-    ## settings for data ingestion
-    loader {
-      sourcetopic = ${dcos.kafka.fromtopic}
-      sourcetopic = ${?KAFKA_FROM_TOPIC_PROC}
+    directorytowatch = "/Users/myhome/ClarkNet-HTTP"
+    directorytowatch = ${?DIRECTORY_TO_WATCH}
 
-      directorytowatch = "/Users/myhome/ClarkNet-HTTP"
-      directorytowatch = ${?DIRECTORY_TO_WATCH}
-
-      pollinterval = 1 second
-    }
+    pollinterval = 1 second
   }
+}
 
-  # http endpoints of the weblog microservice
-  http {
-    # The port the dashboard listens on
-    port = 7071
-    port = ${?PORT0}
+# http endpoints of the weblog microservice
+http {
+  # The port the dashboard listens on
+  port = 7071
+  port = ${?PORT0}
 
-    # The interface the dashboard listens on
-    interface = "localhost"
-    interface = ${?INTERFACE_PROC}
-  }
+  # The interface the dashboard listens on
+  interface = "localhost"
+  interface = ${?INTERFACE_PROC}
 }
 

--- a/kafka-stream-q-example-proc/src/main/resources/log4j.properties
+++ b/kafka-stream-q-example-proc/src/main/resources/log4j.properties
@@ -1,0 +1,16 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=ERROR, R
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+log4j.appender.R=org.apache.log4j.RollingFileAppender
+log4j.appender.R.File=logs/kafka-server.log
+
+log4j.appender.R.MaxFileSize=100KB
+# Keep one backup file
+log4j.appender.R.MaxBackupIndex=1
+
+# A1 uses PatternLayout.
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/KafkaLocalServer.scala
+++ b/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/KafkaLocalServer.scala
@@ -1,0 +1,194 @@
+package com.lightbend.kafka.scala.server
+
+// Loosely based on Lagom implementation at
+//  https://github.com/lagom/lagom/blob/master/dev/kafka-server/src/main/scala/com/lightbend/lagom/internal/kafka/KafkaLocalServer.scala
+
+import java.io.{ IOException, File }
+import java.nio.file.{ FileVisitOption, Files, Paths }
+import java.util.Properties
+
+import org.apache.curator.test.TestingServer
+import com.typesafe.scalalogging.LazyLogging
+
+import kafka.server.{KafkaConfig, KafkaServerStartable}
+
+import scala.collection.JavaConverters._
+import scala.util.{ Try, Success, Failure }
+import java.util.Comparator
+
+import kafka.admin.{AdminUtils, RackAwareMode}
+import kafka.utils.ZkUtils
+
+class KafkaLocalServer private (kafkaProperties: Properties, zooKeeperServer: ZooKeeperLocalServer)
+  extends LazyLogging {
+
+  import KafkaLocalServer._
+
+  private var broker = null.asInstanceOf[KafkaServerStartable]
+  private val zkUtils : ZkUtils =
+    ZkUtils.apply(s"localhost:${zooKeeperServer.getPort()}", DEFAULT_ZK_SESSION_TIMEOUT_MS, DEFAULT_ZK_CONNECTION_TIMEOUT_MS, false)
+
+  def start(): Unit = {
+
+    broker = KafkaServerStartable.fromProps(kafkaProperties)
+    broker.startup()
+  }
+
+  def stop(): Unit = {
+    if (broker != null) {
+      broker.shutdown()
+      zooKeeperServer.stop()
+      broker = null.asInstanceOf[KafkaServerStartable]
+    }
+  }
+
+  /**
+    * Create a Kafka topic with 1 partition and a replication factor of 1.
+    *
+    * @param topic The name of the topic.
+    */
+  def createTopic(topic: String): Unit = {
+    createTopic(topic, 1, 1, new Properties)
+  }
+
+  /**
+    * Create a Kafka topic with the given parameters.
+    *
+    * @param topic       The name of the topic.
+    * @param partitions  The number of partitions for this topic.
+    * @param replication The replication factor for (the partitions of) this topic.
+    */
+  def createTopic(topic: String, partitions: Int, replication: Int): Unit = {
+    createTopic(topic, partitions, replication, new Properties)
+  }
+
+  /**
+    * Create a Kafka topic with the given parameters.
+    *
+    * @param topic       The name of the topic.
+    * @param partitions  The number of partitions for this topic.
+    * @param replication The replication factor for (partitions of) this topic.
+    * @param topicConfig Additional topic-level configuration settings.
+    */
+  def createTopic(topic: String, partitions: Int, replication: Int, topicConfig: Properties): Unit = {
+    AdminUtils.createTopic(zkUtils, topic, partitions, replication, topicConfig, RackAwareMode.Enforced)
+  }
+
+  def deleteTopic(topic: String) = AdminUtils.deleteTopic(zkUtils, topic)
+}
+
+import Utils._
+
+object KafkaLocalServer extends LazyLogging {
+  final val DefaultPort = 9092
+  final val DefaultResetOnStart = true
+  private val DEFAULT_ZK_SESSION_TIMEOUT_MS = 10 * 1000
+  private val DEFAULT_ZK_CONNECTION_TIMEOUT_MS = 8 * 1000
+
+  final val basDir = "tmp/"
+
+  private final val kafkaDataFolderName = "kafka_data"
+
+  def apply(cleanOnStart: Boolean, localStateDir: Option[String] = None): KafkaLocalServer = 
+    this(DefaultPort, ZooKeeperLocalServer.DefaultPort, cleanOnStart, localStateDir)
+
+  def apply(kafkaPort: Int, zookeeperServerPort: Int, cleanOnStart: Boolean, localStateDir: Option[String]): KafkaLocalServer = {
+
+    // delete kafka data dir on clean start
+    val kafkaDataDir: File = (for {
+      kdir <- dataDirectory(basDir, kafkaDataFolderName)
+      _    <- if (cleanOnStart) deleteDirectory(kdir) else Try(())
+    } yield kdir) match {
+      case Success(d) => d
+      case Failure(ex) => throw ex
+    }
+
+    // delete kafka local state dir on clean start
+    localStateDir.foreach { d =>
+      for {
+        kdir <- dataDirectory("", d)
+        _    <- if (cleanOnStart) deleteDirectory(kdir) else Try(())
+      } yield (())
+    }
+
+    logger.info(s"Kafka data directory is $kafkaDataDir.")
+
+    val kafkaProperties = createKafkaProperties(kafkaPort, zookeeperServerPort, kafkaDataDir)
+
+    val zk = new ZooKeeperLocalServer(zookeeperServerPort, cleanOnStart)
+    zk.start()
+    new KafkaLocalServer(kafkaProperties, zk)
+  }
+
+  /**
+    * Creates a Properties instance for Kafka customized with values passed in argument.
+    */
+  private def createKafkaProperties(kafkaPort: Int, zookeeperServerPort: Int, dataDir: File): Properties = {
+
+    // TODO: Probably should be externalized into properties. Was rushing this in     
+    val kafkaProperties = new Properties
+    kafkaProperties.put(KafkaConfig.ListenersProp, s"PLAINTEXT://localhost:$kafkaPort")
+    kafkaProperties.put(KafkaConfig.ZkConnectProp, s"localhost:$zookeeperServerPort")
+    kafkaProperties.put(KafkaConfig.ZkConnectionTimeoutMsProp, "6000")
+    kafkaProperties.put(KafkaConfig.BrokerIdProp, "0")
+    kafkaProperties.put(KafkaConfig.NumNetworkThreadsProp, "3")
+    kafkaProperties.put(KafkaConfig.NumIoThreadsProp, "8")
+    kafkaProperties.put(KafkaConfig.SocketSendBufferBytesProp, "102400")
+    kafkaProperties.put(KafkaConfig.SocketReceiveBufferBytesProp, "102400")
+    kafkaProperties.put(KafkaConfig.SocketRequestMaxBytesProp, "104857600")
+    kafkaProperties.put(KafkaConfig.NumPartitionsProp, "1")
+    kafkaProperties.put(KafkaConfig.NumRecoveryThreadsPerDataDirProp, "1")
+    kafkaProperties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
+    kafkaProperties.put(KafkaConfig.TransactionsTopicReplicationFactorProp, "1")
+    kafkaProperties.put(KafkaConfig.LogRetentionTimeHoursProp, "2")
+    kafkaProperties.put(KafkaConfig.LogSegmentBytesProp, "1073741824")
+    kafkaProperties.put(KafkaConfig.LogCleanupIntervalMsProp, "300000")
+    kafkaProperties.put(KafkaConfig.AutoCreateTopicsEnableProp, "true")
+    kafkaProperties.put(KafkaConfig.ControlledShutdownEnableProp, "true")
+    kafkaProperties.put(KafkaConfig.LogDirProp, dataDir.getAbsolutePath)
+
+    kafkaProperties
+  }
+}
+
+private class ZooKeeperLocalServer(port: Int, cleanOnStart: Boolean) extends LazyLogging {
+
+  import KafkaLocalServer._
+  import ZooKeeperLocalServer._
+
+  private var zooKeeper = null.asInstanceOf[TestingServer]
+
+  def start(): Unit = {
+    // delete kafka data dir on clean start
+    val zookeeperDataDir: File = (for {
+      zdir <- dataDirectory(basDir, zookeeperDataFolderName)
+      _    <- if (cleanOnStart) deleteDirectory(zdir) else Try(())
+    } yield zdir) match {
+      case Success(d) => d
+      case Failure(ex) => throw ex
+    }
+    logger.info(s"Zookeeper data directory is $zookeeperDataDir.")
+
+    zooKeeper = new TestingServer(port, zookeeperDataDir, false)
+
+    zooKeeper.start() // blocking operation
+  }
+
+  def stop(): Unit = {
+    if (zooKeeper != null)
+      try {
+        zooKeeper.stop()
+        zooKeeper = null.asInstanceOf[TestingServer]
+      }
+      catch {
+        case _: IOException => () // nothing to do if an exception is thrown while shutting down
+      }
+  }
+
+  def getPort() : Int = port
+}
+
+object ZooKeeperLocalServer {
+  final val DefaultPort = 2181
+  private final val zookeeperDataFolderName = "zookeeper_data"
+}

--- a/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/MessageListener.scala
+++ b/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/MessageListener.scala
@@ -1,0 +1,85 @@
+package com.lightbend.kafka.scala.server
+
+import org.apache.kafka.clients.consumer.{ ConsumerConfig, KafkaConsumer }
+import org.apache.kafka.streams.KeyValue
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+
+
+object MessageListener {
+  private val AUTO_COMMIT_INTERVAL_MS_CONFIG = "1000" // Frequency of offset commits
+  private val SESSION_TIMEOUT_MS_CONFIG = "30000" // The timeout used to detect failures - should be greater then processing time
+  private val MAX_POLL_RECORDS_CONFIG = "50" // Max number of records consumed in a single poll
+
+  def consumerProperties(brokers: String, group: String, keyDeserializer: String, valueDeserializer: String): Map[String, AnyRef] = {
+    Map[String, AnyRef](
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> brokers,
+      ConsumerConfig.GROUP_ID_CONFIG -> group,
+      ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> "true",
+      ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG -> AUTO_COMMIT_INTERVAL_MS_CONFIG,
+      ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG -> SESSION_TIMEOUT_MS_CONFIG,
+      ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> MAX_POLL_RECORDS_CONFIG,
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "latest",
+      ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG -> keyDeserializer,
+      ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG -> valueDeserializer
+    )
+  }
+
+  def apply[K, V](brokers: String, topic: String, group: String, keyDeserializer: String, valueDeserializer: String,
+                  processor: RecordProcessorTrait[K, V]): MessageListener[K, V] =
+    new MessageListener[K, V](brokers, topic, group, keyDeserializer, valueDeserializer, processor)
+}
+
+class MessageListener[K, V](
+  brokers: String, 
+  topic: String, 
+  group: String, 
+  keyDeserializer: String, 
+  valueDeserializer: String,
+  processor: RecordProcessorTrait[K, V]) {
+
+  import MessageListener._
+
+  def readKeyValues(maxMessages: Int): List[KeyValue[K, V]] = {
+    val pollIntervalMs = 100
+    val maxTotalPollTimeMs = 2000
+    var totalPollTimeMs = 0
+
+    val consumer = new KafkaConsumer[K, V](consumerProperties(brokers, group, keyDeserializer, valueDeserializer).asJava)
+    consumer.subscribe(Seq(topic).asJava)
+
+    val consumedValues = ListBuffer.empty[KeyValue[K, V]]
+
+    while (totalPollTimeMs < maxTotalPollTimeMs && continueConsuming(consumedValues.size, maxMessages)) {
+      totalPollTimeMs = totalPollTimeMs + pollIntervalMs
+      val records = consumer.poll(pollIntervalMs)
+      records.asScala.foreach { record => 
+        processor.processRecord(record)
+        consumedValues += new KeyValue(record.key, record.value)
+      }
+    }
+    consumer.close()
+    consumedValues.toList
+  }
+
+  def continueConsuming(messagesConsumed: Int, maxMessages: Int): Boolean = {
+    maxMessages <= 0 || messagesConsumed < maxMessages
+  }
+
+  def waitUntilMinKeyValueRecordsReceived(expectedNumRecords: Int, waitTime: Long, 
+    startTime: Long = System.currentTimeMillis(), 
+    accumData: ListBuffer[KeyValue[K, V]] = ListBuffer.empty[KeyValue[K, V]]): List[KeyValue[K, V]] = {
+
+    val readData = readKeyValues(-1)
+    accumData ++= readData
+
+    if (accumData.size >= expectedNumRecords) accumData.toList
+    else if (System.currentTimeMillis() > startTime + waitTime) {
+      throw new AssertionError(
+        s"Expected $expectedNumRecords but received only ${accumData.size} records before timeout $waitTime ms")
+    } else {
+      Thread.sleep(Math.min(waitTime, 1000L))
+      waitUntilMinKeyValueRecordsReceived(expectedNumRecords, waitTime, startTime, accumData)
+    }
+  }
+}

--- a/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/MessageSender.scala
+++ b/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/MessageSender.scala
@@ -1,0 +1,60 @@
+package com.lightbend.kafka.scala.server
+
+import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata }
+import java.util.Properties
+
+object MessageSender {
+  private val ACKS_CONFIG = "all" // Blocking on the full commit of the record
+  private val RETRIES_CONFIG = "1" // Number of retries on put
+  private val BATCH_SIZE_CONFIG = "1024" // Buffers for unsent records for each partition - controlls batching
+  private val LINGER_MS_CONFIG = "1" // Timeout for more records to arive - controlls batching
+
+  private val BUFFER_MEMORY_CONFIG = "1024000" // Controls the total amount of memory available to the producer for buffering. 
+                                               // If records are sent faster than they can be transmitted to the server then this 
+                                               // buffer space will be exhausted. When the buffer space is exhausted additional 
+                                               // send calls will block. The threshold for time to block is determined by max.block.ms 
+                                               // after which it throws a TimeoutException.
+
+  def providerProperties(brokers: String, keySerializer: String, valueSerializer: String): Properties = {
+    val props = new Properties
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+    props.put(ProducerConfig.ACKS_CONFIG, ACKS_CONFIG)
+    props.put(ProducerConfig.RETRIES_CONFIG, RETRIES_CONFIG)
+    props.put(ProducerConfig.BATCH_SIZE_CONFIG, BATCH_SIZE_CONFIG)
+    props.put(ProducerConfig.LINGER_MS_CONFIG, LINGER_MS_CONFIG)
+    props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, BUFFER_MEMORY_CONFIG)
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer)
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer)
+    props
+  }
+
+  def apply[K, V](brokers: String, keySerializer: String, valueSerializer: String): MessageSender[K, V] =
+    new MessageSender[K, V](brokers, keySerializer, valueSerializer)
+}
+
+class MessageSender[K, V](val brokers: String, val keySerializer: String, val valueSerializer: String) {
+
+  import MessageSender._
+  val producer = new KafkaProducer[K, V](providerProperties(brokers, keySerializer, valueSerializer))
+
+  def writeKeyValue(topic: String, key: K, value: V): Unit = {
+    producer.send(new ProducerRecord[K, V](topic, key, value)).get
+    producer.flush()
+  }
+
+  def writeValue(topic: String, value: V): Unit = {
+    producer.send(new ProducerRecord[K, V](topic, null.asInstanceOf[K], value)).get
+    producer.flush()
+  }
+
+  def batchWriteValue(topic: String, batch: Seq[V]): Seq[RecordMetadata] = {
+    val result = batch.map(value => {
+      producer.send(new ProducerRecord[K, V](topic, null.asInstanceOf[K], value)).get})
+    producer.flush()
+    result
+  }
+
+  def close(): Unit = {
+    producer.close()
+  }
+}

--- a/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/RecordProcessorTrait.scala
+++ b/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/RecordProcessorTrait.scala
@@ -1,0 +1,9 @@
+package com.lightbend.kafka.scala.server
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+// A trait, that should be implemented by any listener implementation
+
+trait RecordProcessorTrait[K, V] {
+  def processRecord(record: ConsumerRecord[K, V]): Unit
+}

--- a/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/Utils.scala
+++ b/kafka-stream-q-example-proc/src/main/scala/com/lightbend/kafka/scala/server/Utils.scala
@@ -1,0 +1,31 @@
+package com.lightbend.kafka.scala.server
+
+
+import java.io.File
+import java.nio.file.{ FileVisitOption, Files, Paths }
+import java.util.Comparator
+
+import scala.util.{ Try, Success, Failure }
+import scala.collection.JavaConverters._
+
+object Utils {
+  def deleteDirectory(directory: File): Try[Unit] = Try {
+    if (directory.exists()) {
+      val rootPath = Paths.get(directory.getAbsolutePath)
+
+      val files = Files.walk(rootPath, FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).iterator().asScala
+      files.foreach(Files.delete)
+    } 
+  }
+
+  def dataDirectory(baseDir: String, directoryName: String): Try[File] = Try {
+
+    val dataDirectory = new File(baseDir + directoryName)
+
+    if (dataDirectory.exists() && !dataDirectory.isDirectory())
+      throw new IllegalArgumentException(
+        s"Cannot use $directoryName as a directory name because a file with that name already exists in $dataDirectory.")
+
+    dataDirectory
+  }
+}


### PR DESCRIPTION
Exactly the same PR as https://github.com/lightbend/kafka-streams-scala/pull/20 but for the second application.

This PR does the following:

1. Enables application to run using a bundled kafka local server. This can be controlled through a config entry in `application.conf`.
2. Changes namespace in config. Had a dcos as a leftover from FDP config.
3. Updates `README` to include local kafka server based run