### PR TITLE
Added publish commands to build. Now publishes to Sonatype.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,4 +28,30 @@ libraryDependencies ++= Seq(
 
 testFrameworks += new TestFramework("minitest.runner.Framework")
 
-publishTo := Some(Resolver.file("file", new File(Path.userHome.absolutePath + "/.m2/repository")))
+licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+
+developers := List(
+  Developer("debasishg", "Debasish Ghosh", "@debasishg", url("https://github.com/debasishg")),
+  Developer("blublinsky", "Boris Lublinsky", "@blublinsky", url("https://github.com/blublinsky")),
+  Developer("maasg", "Gerard Maas", "@maasg", url("https://github.com/maasg"))
+)
+
+organizationName := "lightbend"
+
+organizationHomepage := Some(url("http://lightbend.com/"))
+
+homepage := scmInfo.value map (_.browseUrl)
+
+scmInfo := Some(ScmInfo(url("https://github.com/lightbend/kafka-streams-scala"), "git@github.com:lightbend/kafka-streams-scala.git"))
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+  else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
+
+publishMavenStyle := true
+
+publishArtifact in Test := false


### PR DESCRIPTION
This PR adds the capability to publish artifacts to Sonatype. 

Publish to Sonatype is quite unstable as the staging process (`publishSigned`) frequently fails with gateway timeout exception (http code: 504). Was able to do `publishSigned` after a few attempts. Then when I tried to close the staging repo (as per the workflow), the Sonatype UI threw a 500 exception. But I found that all the artifacts have been copied to `releases` folder. Though sync to Maven Central has not yet happened.

I raised the issue in #tooling Slack channel and awaiting any suggestion.

Any better alternative welcome!