### PR TITLE
Implicit Serdes

### DIFF
--- a/src/main/scala/com/lightbend/kafka/scala/streams/KTableS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KTableS.scala
@@ -9,6 +9,7 @@ import org.apache.kafka.streams.state.KeyValueStore
 import org.apache.kafka.common.utils.Bytes
 import ImplicitConversions._
 import FunctionConversions._
+import org.apache.kafka.common.serialization.Serde
 
 /**
  * Wraps the Java class KTable and delegates method calls to the underlying Java object.
@@ -48,8 +49,8 @@ class KTableS[K, V](val inner: KTable[K, V]) {
     inner.toStream[KR](mapper.asKeyValueMapper)
   }
 
-  def groupBy[KR, VR](selector: (K, V) => (KR, VR)): KGroupedTableS[KR, VR] = {
-    inner.groupBy(selector.asKeyValueMapper)
+  def groupBy[KR, VR](selector: (K, V) => (KR, VR))(implicit keySerde: Serde[KR], valueSerde: Serde[VR]): KGroupedTableS[KR, VR] = {
+    inner.groupBy(selector.asKeyValueMapper, Serialized.`with`(keySerde, valueSerde))
   }
 
   def groupBy[KR, VR](selector: (K, V) => (KR, VR),

--- a/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
@@ -7,6 +7,7 @@ package com.lightbend.kafka.scala.streams
 import java.util.regex.Pattern
 
 import com.lightbend.kafka.scala.streams.ImplicitConversions._
+import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.common.utils.Bytes
 import org.apache.kafka.streams.kstream.{GlobalKTable, Materialized}
 import org.apache.kafka.streams.processor.{ProcessorSupplier, StateStore}
@@ -20,25 +21,26 @@ import scala.collection.JavaConverters._
   */
 class StreamsBuilderS(inner: StreamsBuilder = new StreamsBuilder) {
 
-  def stream[K, V](topic: String): KStreamS[K, V] =
-    inner.stream[K, V](topic)
+  def stream[K, V](topic: String)(implicit keySerde: Serde[K], valueSerde: Serde[V]): KStreamS[K, V] =
+    inner.stream[K, V](topic, Consumed.`with`(keySerde, valueSerde))
 
   def stream[K, V](topic: String, consumed: Consumed[K, V]): KStreamS[K, V] =
     inner.stream[K, V](topic, consumed)
 
-  def stream[K, V](topics: List[String]): KStreamS[K, V] =
-    inner.stream[K, V](topics.asJava)
+  def stream[K, V](topics: List[String])(implicit keySerde: Serde[K], valueSerde: Serde[V]): KStreamS[K, V] =
+    inner.stream[K, V](topics.asJava, Consumed.`with`(keySerde, valueSerde))
 
   def stream[K, V](topics: List[String], consumed: Consumed[K, V]): KStreamS[K, V] =
     inner.stream[K, V](topics.asJava, consumed)
 
-  def stream[K, V](topicPattern: Pattern): KStreamS[K, V] =
-    inner.stream[K, V](topicPattern)
+  def stream[K, V](topicPattern: Pattern)(implicit keySerde: Serde[K], valueSerde: Serde[V]): KStreamS[K, V] =
+    inner.stream[K, V](topicPattern, Consumed.`with`(keySerde, valueSerde))
 
   def stream[K, V](topicPattern: Pattern, consumed: Consumed[K, V]): KStreamS[K, V] =
     inner.stream[K, V](topicPattern, consumed)
 
-  def table[K, V](topic: String): KTableS[K, V] = inner.table[K, V](topic)
+  def table[K, V](topic: String)(implicit keySerde: Serde[K], valueSerde: Serde[V]): KTableS[K, V] =
+    inner.table[K, V](topic, Consumed.`with`(keySerde, valueSerde))
 
   def table[K, V](topic: String, consumed: Consumed[K, V]): KTableS[K, V] =
     inner.table[K, V](topic, consumed)
@@ -51,8 +53,8 @@ class StreamsBuilderS(inner: StreamsBuilder = new StreamsBuilder) {
                   materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, V] =
     inner.table[K, V](topic, materialized)
 
-  def globalTable[K, V](topic: String): GlobalKTable[K, V] =
-    inner.globalTable(topic)
+  def globalTable[K, V](topic: String)(implicit keySerde: Serde[K], valueSerde: Serde[V]): GlobalKTable[K, V] =
+    inner.globalTable(topic, Consumed.`with`(keySerde, valueSerde))
 
   def globalTable[K, V](topic: String, consumed: Consumed[K, V]): GlobalKTable[K, V] =
     inner.globalTable(topic, consumed)

--- a/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
@@ -34,8 +34,8 @@ object KafkaStreamsTest extends TestSuite[KafkaLocalServer] with WordCountTestDa
     //
     // Step 1: Configure and start the processor topology.
     //
-    val stringSerde = Serdes.String()
-    val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
+    implicit val stringSerde = Serdes.String()
+    implicit val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
 
     val streamsConfiguration = new Properties()
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, s"wordcount-${scala.util.Random.nextInt(100)}")

--- a/src/test/scala/com/lightbend/kafka/scala/streams/ProbabilisticCountingScalaIntegrationTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/ProbabilisticCountingScalaIntegrationTest.scala
@@ -86,12 +86,15 @@ object ProbabilisticCountingScalaIntegrationTest extends TestSuite[KafkaLocalSer
     //
     // Step 1: Configure and start the processor topology.
     //
+    implicit val keySerde: Serde[Array[Byte]] = Serdes.ByteArray
+    implicit val valueSerde: Serde[String] = Serdes.String
+
     val streamsConfiguration: Properties = {
       val p = new Properties()
       p.put(StreamsConfig.APPLICATION_ID_CONFIG, s"probabilistic-counting-scala-integration-test-${scala.util.Random.nextInt(100)}")
       p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
-      p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray.getClass.getName)
-      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, keySerde.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, valueSerde.getClass.getName)
       p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "10000")
       p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
       p

--- a/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTest.scala
@@ -64,8 +64,8 @@ object StreamToTableJoinScalaIntegrationTest extends TestSuite[KafkaLocalServer]
     //
     // Step 1: Configure and start the processor topology.
     //
-    val stringSerde: Serde[String] = Serdes.String()
-    val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
+    implicit val stringSerde: Serde[String] = Serdes.String()
+    implicit val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
 
     val streamsConfiguration: Properties = {
       val p = new Properties()
@@ -96,7 +96,7 @@ object StreamToTableJoinScalaIntegrationTest extends TestSuite[KafkaLocalServer]
         .map((_, regionWithClicks) => regionWithClicks)
 
         // Compute the total per region by summing the individual click counts per region.
-        .groupByKey(Serialized.`with`(stringSerde, longSerde))
+        .groupByKey()
         .reduce(_ + _)
 
     // Write the (continuously updating) results to the output topic.


### PR DESCRIPTION
First of all, thanks to Lightbend for publishing and committing to maintain this excellent library. 

One of my annoyances of the java API for kafka streams is having to pass explicit `Serde`s to lots of methods, in the 1.0.0 api in the form of `Serialized` or `Produced`. Although most methods have overloads without a serializer, those may result in runtime errors if no appropriate serializer is configured.

In scala we can make nice use of implicits for passing the `Serde`s. In this PR I propose some additions to the scala api that take implicit `Serde`s instead of explicit `Produced` and `Serialized`. Unfortunately to get it to compile, I had to remove the overloads without those parameters, but as the test code shows, the change in client code is minor compared to the advantages.