### PR TITLE
Explicit SAM conversions for Scala 2.11

### DIFF
--- a/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedStreamS.scala
@@ -36,13 +36,17 @@ class KGroupedStreamS[K, V](inner: KGroupedStream[K, V]) {
   def reduce(reducer: (V, V) => V,
     materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, V] = {
 
-    inner.reduce((v1: V, v2: V) => reducer(v1, v2), materialized)
+    // need this explicit asReducer for Scala 2.11 or else the SAM conversion doesn't take place
+    // works perfectly with Scala 2.12 though
+    inner.reduce(((v1: V, v2: V) => reducer(v1, v2)).asReducer, materialized)
   }
 
   def reduce(reducer: (V, V) => V,
     storeName: String): KTableS[K, V] = {
 
-    inner.reduce((v1: V, v2: V) => reducer(v1, v2), Materialized.as[K, V, KeyValueStore[Bytes, Array[Byte]]](storeName))
+    // need this explicit asReducer for Scala 2.11 or else the SAM conversion doesn't take place
+    // works perfectly with Scala 2.12 though
+    inner.reduce(((v1: V, v2: V) => reducer(v1, v2)).asReducer, Materialized.as[K, V, KeyValueStore[Bytes, Array[Byte]]](storeName))
   }
 
   def aggregate[VR](initializer: () => VR,

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedTableS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KGroupedTableS.scala
@@ -28,14 +28,18 @@ class KGroupedTableS[K, V](inner: KGroupedTable[K, V]) {
   def reduce(adder: (V, V) => V,
     subtractor: (V, V) => V): KTableS[K, V] = {
 
-    inner.reduce((v1, v2) => adder(v1, v2), (v1, v2) => subtractor(v1, v2))
+    // need this explicit asReducer for Scala 2.11 or else the SAM conversion doesn't take place
+    // works perfectly with Scala 2.12 though
+    inner.reduce(((v1, v2) => adder(v1, v2)).asReducer, ((v1, v2) => subtractor(v1, v2)).asReducer)
   }
 
   def reduce(adder: (V, V) => V,
     subtractor: (V, V) => V,
     materialized: Materialized[K, V, ByteArrayKVStore]): KTableS[K, V] = {
 
-    inner.reduce((v1, v2) => adder(v1, v2), (v1, v2) => subtractor(v1, v2), materialized)
+    // need this explicit asReducer for Scala 2.11 or else the SAM conversion doesn't take place
+    // works perfectly with Scala 2.12 though
+    inner.reduce(((v1, v2) => adder(v1, v2)).asReducer, ((v1, v2) => subtractor(v1, v2)).asReducer, materialized)
   }
 
   def aggregate[VR](initializer: () => VR,
@@ -49,7 +53,6 @@ class KGroupedTableS[K, V](inner: KGroupedTable[K, V]) {
     adder: (K, V, VR) => VR,
     subtractor: (K, V, VR) => VR,
     materialized: Materialized[K, VR, ByteArrayKVStore]): KTableS[K, VR] = {
-
 
     inner.aggregate(initializer.asInitializer, adder.asAggregator, subtractor.asAggregator, materialized)
   }


### PR DESCRIPTION
Fix https://github.com/lightbend/kafka-streams-scala/issues/41 - trigger some of the SAM conversions for multi-argument methods explicitly for Scala 2.11