### PR TITLE
Implementation of Implicit (De-)Serializer techniques

### DIFF
--- a/src/main/scala/com/lightbend/kafka/scala/streams/ImplicitConversions.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/ImplicitConversions.scala
@@ -5,7 +5,8 @@
 package com.lightbend.kafka.scala.streams
 
 import org.apache.kafka.streams.kstream._
-import org.apache.kafka.streams.KeyValue
+import org.apache.kafka.streams.{ KeyValue, Consumed }
+import org.apache.kafka.common.serialization.Serde
 
 import scala.language.implicitConversions
 
@@ -35,5 +36,22 @@ object ImplicitConversions {
 
   implicit def Tuple2ToKeyValue[K, V](tuple: (K, V)): KeyValue[K, V] = new KeyValue(tuple._1, tuple._2)
 
-}
+  case class Perhaps[E](value: Option[E]) {
+    def fold[F](ifAbsent: => F)(ifPresent: E => F): F = {
+      value.fold(ifAbsent)(ifPresent)
+    }
+  }
 
+  implicit def perhaps[E](implicit ev: E = null): Perhaps[E] = {
+    Perhaps(Option(ev))
+  }
+
+  implicit def SerializedFromSerde[K,V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Serialized[K,V] = 
+    Serialized.`with`(keySerde, valueSerde)
+
+  implicit def ConsumedFromSerde[K,V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Consumed[K,V] = 
+    Consumed.`with`(keySerde, valueSerde)
+
+  implicit def ProducedFromSerde[K,V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Produced[K,V] = 
+    Produced.`with`(keySerde, valueSerde)
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/ImplicitConversions.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/ImplicitConversions.scala
@@ -36,6 +36,9 @@ object ImplicitConversions {
 
   implicit def Tuple2ToKeyValue[K, V](tuple: (K, V)): KeyValue[K, V] = new KeyValue(tuple._1, tuple._2)
 
+  // technique for optional implicits adopted from 
+  // http://missingfaktor.blogspot.in/2013/12/optional-implicit-trick-in-scala.html
+
   case class Perhaps[E](value: Option[E]) {
     def fold[F](ifAbsent: => F)(ifPresent: E => F): F = {
       value.fold(ifAbsent)(ifPresent)
@@ -45,6 +48,9 @@ object ImplicitConversions {
   implicit def perhaps[E](implicit ev: E = null): Perhaps[E] = {
     Perhaps(Option(ev))
   }
+
+  // we would also like to allow users implicit serdes
+  // and these implicits will convert them to `Serialized`, `Produced` or `Consumed`
 
   implicit def SerializedFromSerde[K,V](implicit keySerde: Serde[K], valueSerde: Serde[V]): Serialized[K,V] = 
     Serialized.`with`(keySerde, valueSerde)

--- a/src/main/scala/com/lightbend/kafka/scala/streams/KTableS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/KTableS.scala
@@ -48,14 +48,12 @@ class KTableS[K, V](val inner: KTable[K, V]) {
     inner.toStream[KR](mapper.asKeyValueMapper)
   }
 
-  def groupBy[KR, VR](selector: (K, V) => (KR, VR)): KGroupedTableS[KR, VR] = {
-    inner.groupBy(selector.asKeyValueMapper)
-  }
-
-  def groupBy[KR, VR](selector: (K, V) => (KR, VR),
-    serialized: Serialized[KR, VR]): KGroupedTableS[KR, VR] = {
-
-    inner.groupBy(selector.asKeyValueMapper, serialized)
+  def groupBy[KR, VR](selector: (K, V) => (KR, VR))(implicit serialized: Perhaps[Serialized[KR, VR]]): KGroupedTableS[KR, VR] = {
+    serialized.fold[KGroupedTableS[KR, VR]] { 
+      inner.groupBy(selector.asKeyValueMapper) 
+    } { implicit ev => 
+      inner.groupBy(selector.asKeyValueMapper, ev) 
+    }
   }
 
   def join[VO, VR](other: KTableS[K, VO],

--- a/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/StreamsBuilderS.scala
@@ -20,50 +20,28 @@ import scala.collection.JavaConverters._
   */
 class StreamsBuilderS(inner: StreamsBuilder = new StreamsBuilder) {
 
-  def stream[K, V](topic: String): KStreamS[K, V] =
-    inner.stream[K, V](topic)
+  def stream[K, V](topic: String)(implicit consumed: Perhaps[Consumed[K, V]]): KStreamS[K, V] =
+    consumed.fold[KStreamS[K, V]] { inner.stream[K, V](topic) } { implicit ev => inner.stream[K, V](topic, ev) }
 
-  def stream[K, V](topic: String, consumed: Consumed[K, V]): KStreamS[K, V] =
-    inner.stream[K, V](topic, consumed)
+  def stream[K, V](topics: List[String])(implicit consumed: Perhaps[Consumed[K, V]]): KStreamS[K, V] =
+    consumed.fold[KStreamS[K, V]] { inner.stream[K, V](topics.asJava) } { implicit ev => inner.stream[K, V](topics.asJava, ev) }
 
-  def stream[K, V](topics: List[String]): KStreamS[K, V] =
-    inner.stream[K, V](topics.asJava)
+  def stream[K, V](topicPattern: Pattern)(implicit consumed: Perhaps[Consumed[K, V]]): KStreamS[K, V] =
+    consumed.fold[KStreamS[K, V]] { inner.stream[K, V](topicPattern) } { implicit ev => inner.stream[K, V](topicPattern, ev) }
 
-  def stream[K, V](topics: List[String], consumed: Consumed[K, V]): KStreamS[K, V] =
-    inner.stream[K, V](topics.asJava, consumed)
+  def table[K, V](topic: String)(implicit consumed: Perhaps[Consumed[K, V]]): KTableS[K, V] = 
+    consumed.fold[KTableS[K, V]] { inner.table[K, V](topic) } { implicit ev => inner.table[K, V](topic, ev) }
 
-  def stream[K, V](topicPattern: Pattern): KStreamS[K, V] =
-    inner.stream[K, V](topicPattern)
+  def table[K, V](topic: String, materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]])
+    (implicit consumed: Perhaps[Consumed[K, V]]): KTableS[K, V] =
+    consumed.fold[KTableS[K, V]] { inner.table(topic, materialized) } { implicit ev => inner.table[K, V](topic, ev, materialized) }
 
-  def stream[K, V](topicPattern: Pattern, consumed: Consumed[K, V]): KStreamS[K, V] =
-    inner.stream[K, V](topicPattern, consumed)
+  def globalTable[K, V](topic: String)(implicit consumed: Perhaps[Consumed[K, V]]): GlobalKTable[K, V] =
+    consumed.fold[GlobalKTable[K, V]] { inner.globalTable(topic) } { implicit ev => inner.globalTable(topic, ev) }
 
-  def table[K, V](topic: String): KTableS[K, V] = inner.table[K, V](topic)
-
-  def table[K, V](topic: String, consumed: Consumed[K, V]): KTableS[K, V] =
-    inner.table[K, V](topic, consumed)
-
-  def table[K, V](topic: String, consumed: Consumed[K, V],
-                  materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, V] =
-    inner.table[K, V](topic, consumed, materialized)
-
-  def table[K, V](topic: String,
-                  materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): KTableS[K, V] =
-    inner.table[K, V](topic, materialized)
-
-  def globalTable[K, V](topic: String): GlobalKTable[K, V] =
-    inner.globalTable(topic)
-
-  def globalTable[K, V](topic: String, consumed: Consumed[K, V]): GlobalKTable[K, V] =
-    inner.globalTable(topic, consumed)
-
-  def globalTable[K, V](topic: String, consumed: Consumed[K, V],
-                        materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): GlobalKTable[K, V] =
-    inner.globalTable(topic, consumed, materialized)
-
-  def globalTable[K, V](topic: String,
-                        materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]]): GlobalKTable[K, V] =
-    inner.globalTable(topic, materialized)
+  def globalTable[K, V](topic: String, materialized: Materialized[K, V, KeyValueStore[Bytes, Array[Byte]]])
+    (implicit consumed: Perhaps[Consumed[K, V]]): GlobalKTable[K, V] =
+    consumed.fold[GlobalKTable[K, V]] { inner.globalTable(topic, materialized) } { implicit ev => inner.globalTable(topic, ev, materialized) }
 
   def addStateStore(builder: StoreBuilder[_ <: StateStore]): StreamsBuilder = inner.addStateStore(builder)
 

--- a/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/KafkaStreamsTest.scala
@@ -11,8 +11,8 @@ import com.lightbend.kafka.scala.server.{KafkaLocalServer, MessageListener, Mess
 import minitest.TestSuite
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization._
-import org.apache.kafka.streams.kstream.Produced
 import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsConfig}
+import ImplicitConversions._
 
 object KafkaStreamsTest extends TestSuite[KafkaLocalServer] with WordCountTestData {
 
@@ -34,8 +34,8 @@ object KafkaStreamsTest extends TestSuite[KafkaLocalServer] with WordCountTestDa
     //
     // Step 1: Configure and start the processor topology.
     //
-    val stringSerde = Serdes.String()
-    val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
+    implicit val stringSerde = Serdes.String()
+    implicit val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
 
     val streamsConfiguration = new Properties()
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, s"wordcount-${scala.util.Random.nextInt(100)}")
@@ -57,7 +57,7 @@ object KafkaStreamsTest extends TestSuite[KafkaLocalServer] with WordCountTestDa
         .groupBy((k, v) => v)
         .count()
 
-    wordCounts.toStream.to(outputTopic, Produced.`with`(stringSerde, longSerde))
+    wordCounts.toStream.to(outputTopic)
 
     val streams = new KafkaStreams(builder.build, streamsConfiguration)
     streams.start()

--- a/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
@@ -73,7 +73,7 @@ object StreamToTableJoinScalaIntegrationTestImplicitSerdes extends TestSuite[Kaf
       p.put(StreamsConfig.CLIENT_ID_CONFIG, "join-scala-integration-test-implicit-serdes-standard-consumer")
       p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
       p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
-      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
       p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
       p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
       p
@@ -97,9 +97,7 @@ object StreamToTableJoinScalaIntegrationTestImplicitSerdes extends TestSuite[Kaf
 
         // Compute the total per region by summing the individual click counts per region.
         .groupByKey
-
-        // .reduce(_ + _, "local_state_data") // doesn't work in Scala 2.11, works with Scala 2.12
-        .reduce((firstClicks: Long, secondClicks: Long) => firstClicks + secondClicks, "local_state_data")
+        .reduce(_ + _)
 
     // Write the (continuously updating) results to the output topic.
     clicksPerRegion.toStream.to(outputTopic)

--- a/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerialized.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerialized.scala
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Adapted from Confluent Inc. whose copyright is reproduced below.
+ */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams
+
+import java.util.Properties
+import minitest.TestSuite
+import com.lightbend.kafka.scala.server.{ KafkaLocalServer, MessageSender, MessageListener, RecordProcessorTrait }
+
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
+import org.apache.kafka.streams.kstream.{ Serialized, Produced }
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import ImplicitConversions._
+
+/**
+  * End-to-end integration test that demonstrates how to perform a join between a KStream and a
+  * KTable (think: KStream.leftJoin(KTable)), i.e. an example of a stateful computation.
+  *
+  * See StreamToTableJoinIntegrationTest for the equivalent Java example.
+  *
+  * Note: We intentionally use JUnit4 (wrapped by ScalaTest) for implementing this Scala integration
+  * test so it is easier to compare this Scala code with the equivalent Java code at
+  * StreamToTableJoinIntegrationTest.  One difference is that, to simplify the Scala/Junit integration, we
+  * switched from BeforeClass (which must be `static`) to Before as well as from @ClassRule (which
+  * must be `static` and `public`) to a workaround combination of `@Rule def` and a `private val`.
+  */
+
+object StreamToTableJoinScalaIntegrationTestImplicitSerialized extends TestSuite[KafkaLocalServer] with StreamToTableJoinTestData {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count clicks per region") { server =>
+
+    server.createTopic(userClicksTopic)
+    server.createTopic(userRegionsTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val stringSerde: Serde[String] = Serdes.String()
+    val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
+
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p.put(StreamsConfig.APPLICATION_ID_CONFIG, s"stream-table-join-scala-integration-test-implicit-ser-${scala.util.Random.nextInt(100)}")
+      p.put(StreamsConfig.CLIENT_ID_CONFIG, "join-scala-integration-test-implicit-ser-standard-consumer")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long.getClass.getName)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+      p
+    }
+
+    implicit val consumedStringString = Consumed.`with`(stringSerde, stringSerde)
+
+    val builder = new StreamsBuilderS()
+
+    implicit val consumedStringLong = Consumed.`with`(stringSerde, longSerde)
+    val userClicksStream: KStreamS[String, Long] = builder.stream(userClicksTopic)
+
+    val userRegionsTable: KTableS[String, String] = builder.table(userRegionsTopic)
+
+    implicit val producedStringLong = Produced.`with`(stringSerde, longSerde)
+
+    implicit val serialized: Serialized[String, Long] = Serialized.`with`(stringSerde, longSerde)
+
+    // Compute the total per region by summing the individual click counts per region.
+    val clicksPerRegion: KTableS[String, Long] = 
+      userClicksStream
+
+        // Join the stream against the table.
+        .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
+
+        // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+        .map((_, regionWithClicks) => regionWithClicks)
+
+        // Compute the total per region by summing the individual click counts per region.
+        .groupByKey
+
+        // .reduce(_ + _, "local_state_data") // doesn't work in Scala 2.11, works with Scala 2.12
+        .reduce((firstClicks: Long, secondClicks: Long) => firstClicks + secondClicks, "local_state_data")
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic)
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build, streamsConfiguration)
+
+    streams.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      override def uncaughtException(t: Thread, e: Throwable): Unit = try {
+        println(s"Stream terminated because of uncaught exception .. Shutting down app", e)
+        e.printStackTrace
+        val closed = streams.close()
+        println(s"Exiting application after streams close ($closed)")
+      } catch {
+        case x: Exception => x.printStackTrace
+      } finally {
+        println("Exiting application ..")
+        System.exit(-1)
+      }
+    })
+
+    streams.start()
+
+    //
+    // Step 2: Publish user-region information.
+    //
+    // To keep this code example simple and easier to understand/reason about, we publish all
+    // user-region records before any user-click records (cf. step 3).  In practice though,
+    // data records would typically be arriving concurrently in both input streams/topics.
+    val sender1 = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName) 
+    userRegions.foreach(r => sender1.writeKeyValue(userRegionsTopic, r.key, r.value))
+
+    //
+    // Step 3: Publish some user click events.
+    //
+    val sender2 = MessageSender[String, Long](brokers, classOf[StringSerializer].getName, classOf[LongSerializer].getName) 
+    userClicks.foreach(r => sender2.writeKeyValue(userClicksTopic, r.key, r.value))
+
+    //
+    // Step 4: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "join-scala-integration-test-standard-consumer", 
+      classOf[StringDeserializer].getName, 
+      classOf[LongDeserializer].getName, 
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedClicksPerRegion.size, 30000)
+    streams.close()
+    assertEquals(l.sortBy(_.key), expectedClicksPerRegion.sortBy(_.key))
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = { 
+      // println(s"Get Message $record")
+    }
+  }
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerialized.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerialized.scala
@@ -74,7 +74,7 @@ object StreamToTableJoinScalaIntegrationTestImplicitSerialized extends TestSuite
       p.put(StreamsConfig.CLIENT_ID_CONFIG, "join-scala-integration-test-implicit-ser-standard-consumer")
       p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
       p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
-      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
       p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
       p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
       p
@@ -105,9 +105,7 @@ object StreamToTableJoinScalaIntegrationTestImplicitSerialized extends TestSuite
 
         // Compute the total per region by summing the individual click counts per region.
         .groupByKey
-
-        // .reduce(_ + _, "local_state_data") // doesn't work in Scala 2.11, works with Scala 2.12
-        .reduce((firstClicks: Long, secondClicks: Long) => firstClicks + secondClicks, "local_state_data")
+        .reduce(_ + _)
 
     // Write the (continuously updating) results to the output topic.
     clicksPerRegion.toStream.to(outputTopic)

--- a/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestMixImplicitSerialized.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestMixImplicitSerialized.scala
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Adapted from Confluent Inc. whose copyright is reproduced below.
+ */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams
+
+import java.util.Properties
+import minitest.TestSuite
+import com.lightbend.kafka.scala.server.{ KafkaLocalServer, MessageSender, MessageListener, RecordProcessorTrait }
+
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
+import org.apache.kafka.streams.kstream.{ Serialized, Produced }
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import ImplicitConversions._
+
+/**
+  * End-to-end integration test that demonstrates how to perform a join between a KStream and a
+  * KTable (think: KStream.leftJoin(KTable)), i.e. an example of a stateful computation.
+  *
+  * See StreamToTableJoinIntegrationTest for the equivalent Java example.
+  *
+  * Note: We intentionally use JUnit4 (wrapped by ScalaTest) for implementing this Scala integration
+  * test so it is easier to compare this Scala code with the equivalent Java code at
+  * StreamToTableJoinIntegrationTest.  One difference is that, to simplify the Scala/Junit integration, we
+  * switched from BeforeClass (which must be `static`) to Before as well as from @ClassRule (which
+  * must be `static` and `public`) to a workaround combination of `@Rule def` and a `private val`.
+  */
+
+object StreamToTableJoinScalaIntegrationTestMixImplicitSerialized extends TestSuite[KafkaLocalServer] with StreamToTableJoinTestData {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count clicks per region") { server =>
+
+    server.createTopic(userClicksTopic)
+    server.createTopic(userRegionsTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val stringSerde: Serde[String] = Serdes.String()
+    val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
+
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p.put(StreamsConfig.APPLICATION_ID_CONFIG, s"stream-table-join-scala-integration-test-mix-implicit-ser-${scala.util.Random.nextInt(100)}")
+      p.put(StreamsConfig.CLIENT_ID_CONFIG, "join-scala-integration-test-mix-implicit-ser-standard-consumer")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+      p
+    }
+
+    val builder = new StreamsBuilderS()
+
+    implicit val consumedStringLong = Consumed.`with`(stringSerde, longSerde)
+    val userClicksStream: KStreamS[String, Long] = builder.stream(userClicksTopic)
+
+    // this will use the default serdes set in config
+    val userRegionsTable: KTableS[String, String] = builder.table(userRegionsTopic)
+
+    implicit val producedStringLong = Produced.`with`(stringSerde, longSerde)
+
+    implicit val serialized: Serialized[String, Long] = Serialized.`with`(stringSerde, longSerde)
+
+    // Compute the total per region by summing the individual click counts per region.
+    val clicksPerRegion: KTableS[String, Long] = 
+      userClicksStream
+
+        // Join the stream against the table.
+        .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
+
+        // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+        .map((_, regionWithClicks) => regionWithClicks)
+
+        // Compute the total per region by summing the individual click counts per region.
+        .groupByKey
+        .reduce(_ + _)
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic)
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build, streamsConfiguration)
+
+    streams.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      override def uncaughtException(t: Thread, e: Throwable): Unit = try {
+        println(s"Stream terminated because of uncaught exception .. Shutting down app", e)
+        e.printStackTrace
+        val closed = streams.close()
+        println(s"Exiting application after streams close ($closed)")
+      } catch {
+        case x: Exception => x.printStackTrace
+      } finally {
+        println("Exiting application ..")
+        System.exit(-1)
+      }
+    })
+
+    streams.start()
+
+    //
+    // Step 2: Publish user-region information.
+    //
+    // To keep this code example simple and easier to understand/reason about, we publish all
+    // user-region records before any user-click records (cf. step 3).  In practice though,
+    // data records would typically be arriving concurrently in both input streams/topics.
+    val sender1 = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName) 
+    userRegions.foreach(r => sender1.writeKeyValue(userRegionsTopic, r.key, r.value))
+
+    //
+    // Step 3: Publish some user click events.
+    //
+    val sender2 = MessageSender[String, Long](brokers, classOf[StringSerializer].getName, classOf[LongSerializer].getName) 
+    userClicks.foreach(r => sender2.writeKeyValue(userClicksTopic, r.key, r.value))
+
+    //
+    // Step 4: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "join-scala-integration-test-standard-consumer", 
+      classOf[StringDeserializer].getName, 
+      classOf[LongDeserializer].getName, 
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedClicksPerRegion.size, 30000)
+    streams.close()
+    assertEquals(l.sortBy(_.key), expectedClicksPerRegion.sortBy(_.key))
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = { 
+      // println(s"Get Message $record")
+    }
+  }
+}
+

--- a/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinTestData.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinTestData.scala
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Adapted from Confluent Inc. whose copyright is reproduced below.
+ */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams
+
+import org.apache.kafka.streams.KeyValue
+
+trait StreamToTableJoinTestData {
+  val brokers = "localhost:9092"
+
+  val userClicksTopic = s"user-clicks.${scala.util.Random.nextInt(100)}"
+  val userRegionsTopic = s"user-regions.${scala.util.Random.nextInt(100)}"
+  val outputTopic = s"output-topic.${scala.util.Random.nextInt(100)}"
+  val localStateDir = "local_state_data"
+
+  // Input 1: Clicks per user (multiple records allowed per user).
+  val userClicks: Seq[KeyValue[String, Long]] = Seq(
+    new KeyValue("alice", 13L),
+    new KeyValue("bob", 4L),
+    new KeyValue("chao", 25L),
+    new KeyValue("bob", 19L),
+    new KeyValue("dave", 56L),
+    new KeyValue("eve", 78L),
+    new KeyValue("alice", 40L),
+    new KeyValue("fang", 99L)
+  )
+
+  // Input 2: Region per user (multiple records allowed per user).
+  val userRegions: Seq[KeyValue[String, String]] = Seq(
+    new KeyValue("alice", "asia"), /* Alice lived in Asia originally... */
+    new KeyValue("bob", "americas"),
+    new KeyValue("chao", "asia"),
+    new KeyValue("dave", "europe"),
+    new KeyValue("alice", "europe"), /* ...but moved to Europe some time later. */
+    new KeyValue("eve", "americas"),
+    new KeyValue("fang", "asia")
+  )
+
+  val expectedClicksPerRegion: Seq[KeyValue[String, Long]] = Seq(
+    new KeyValue("americas", 101L),
+    new KeyValue("europe", 109L),
+    new KeyValue("asia", 124L)
+  )
+}
+


### PR DESCRIPTION
This PR offers a sample implementation of providing implicit serialization / de-serialization in Kafka Streams APIs (Issue https://github.com/lightbend/kafka-streams-scala/issues/46).

*This may not be the final implementation but provides a groundwork for further discussion. It will be great if we can have alternate implementations that make the APIs more compile time safe. An approach has been suggested by @dhoepelman in https://github.com/lightbend/kafka-streams-scala/issues/46. But I could not make the implicit lookup work properly and it became a mess of implicits.*

<h2>Design decisions adopted in the implementation :</h2>

1. The implementation offers implicits to provide the serializers and de-serializers but at the same time also **allows the opt-in to use the default serializers registered in the Kafka Streams config**.
2. The optional implicit pattern is implemented with the usual *null-default-value* trick, but with a difference. The technique used is adopted from [this blog post](http://missingfaktor.blogspot.in/2013/12/optional-implicit-trick-in-scala.html).
3. The standard way to implement the *null-default-value* trick could not be applied as Scala [does not allow](https://stackoverflow.com/a/4652681) a mix of default values and function overloads. And we have quite a few examples of such overloaded functions in the Kafka Streams API set.
4. The implementation allows implicits for the `Serde`s or for `Serialized`, `Consumed` and `Produced`. The test examples demonstrate both, though the implicits for `Serde`s make a cleaner implementation.
5. The implementation does a trade-off in using the *null-default-value* trick as it moves some of the compile time errors to runtime.

<h2>Examples:</h2>

1. The example [StreamToTableJoinScalaIntegrationTestImplicitSerdes](https://github.com/lightbend/kafka-streams-scala/blob/serdes-fold/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala) demonstrates how to use the technique of implicit `Serde`s
2. The example [StreamToTableJoinScalaIntegrationTestImplicitSerialized](https://github.com/lightbend/kafka-streams-scala/blob/serdes-fold/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerialized.scala) demonstrates how to use the technique of implicit `Serialized`, `Consumed` and `Produced`.