### PR TITLE
Add a typesafe-by-default implementation for kafka-streams-scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ licenses := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.
 developers := List(
   Developer("debasishg", "Debasish Ghosh", "@debasishg", url("https://github.com/debasishg")),
   Developer("blublinsky", "Boris Lublinsky", "@blublinsky", url("https://github.com/blublinsky")),
-  Developer("maasg", "Gerard Maas", "@maasg", url("https://github.com/maasg"))
+  Developer("maasg", "Gerard Maas", "@maasg", url("https://github.com/maasg")),
+  Developer("ssaavedra", "Santiago Saavedra", "@ssaavedra", url("https://github.com/ssaavedra"))
 )
 
 organizationName := "lightbend"

--- a/src/main/scala/com/lightbend/kafka/scala/streams/FunctionConversions.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/FunctionConversions.scala
@@ -46,6 +46,10 @@ object FunctionConversions {
     def asReducer: Reducer[V] = (v1, v2) => f(v1, v2)
   }
 
+  implicit class InitializerFromNameRef[T](f: => T) {
+    def asInitializer: Initializer[T] = () => f
+  }
+
   implicit class InitializerFromFunction[T](val f: () => T) extends AnyVal {
     def asInitializer: Initializer[T] = () => f()
   }

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/ImplicitConverters.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/ImplicitConverters.scala
@@ -28,43 +28,42 @@ import org.apache.kafka.streams.kstream._
   */
 object ImplicitConverters {
 
-  implicit final class TSKStreamAuto[K, V]
+  implicit class TSKStreamAuto[K, V]
   (val inner: KStream[K, V])
-    extends
-      AnyVal {
+    extends AnyVal {
     def safe: TSKStream[K, V] =
       new TSKStream[K, V](inner)
   }
 
-  implicit final class TSKTableAuto[K, V]
+  implicit class TSKTableAuto[K, V]
   (val inner: KTable[K, V])
     extends AnyVal {
     def safe: TSKTable[K, V] =
       new TSKTable[K, V](inner)
   }
 
-  implicit final class TSKGroupedStreamAuto[K, V]
+  implicit class TSKGroupedStreamAuto[K, V]
   (val inner: KGroupedStream[K, V])
     extends AnyVal {
     def safe: TSKGroupedStream[K, V] =
       new TSKGroupedStream[K, V](inner)
   }
 
-  implicit final class TSKGroupedTableAuto[K, V]
+  implicit class TSKGroupedTableAuto[K, V]
   (val inner: KGroupedTable[K, V])
     extends AnyVal {
     def safe: TSKGroupedTable[K, V] =
       new TSKGroupedTable[K, V](inner)
   }
 
-  implicit final class TSSessionWindowedKStreamAuto[K, V]
+  implicit class TSSessionWindowedKStreamAuto[K, V]
   (val inner: SessionWindowedKStream[K, V])
     extends AnyVal {
     def safe: TSSessionWindowedKStream[K, V] =
       new TSSessionWindowedKStream[K, V](inner)
   }
 
-  implicit final class TSTimeWindowedKStreamAuto[K, V]
+  implicit class TSTimeWindowedKStreamAuto[K, V]
   (val inner: TimeWindowedKStream[K, V])
     extends AnyVal {
     def safe: TSTimeWindowedKStream[K, V] =

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/ImplicitConverters.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/ImplicitConverters.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.kstream._
   * that no new objects get allocated for the `.safe` call (only the TSxx
   * objects get allocated).
   */
-private[typesafe] object implicits {
+object ImplicitConverters {
 
   implicit final class TSKStreamAuto[K, V]
   (val inner: KStream[K, V])

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/SerdeDerivations.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/SerdeDerivations.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+
+/** These are implicit serdes that can be mixed-in into your Kafka Streams
+  * job, making it easier to work from scala.
+  *
+  * Objects such as [[util.Materialized]],
+  * [[org.apache.kafka.streams.Consumed]],
+  * [[org.apache.kafka.streams.kstream.Produced]] or
+  * [[org.apache.kafka.streams.kstream.Joined]] need to be created from
+  * [[org.apache.kafka.common.serialization.Serde]] instances according to the
+  * types you are handling. When including this class, you will automatically
+  * generate these objects from available implicit Serde instances.
+  */
+trait SerdeDerivations extends derivations.Default
+
+object SerdeDerivations extends SerdeDerivations

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/SerdeSyntax.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/SerdeSyntax.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer}
+
+import scala.language.implicitConversions
+
+/** Adds syntax for defining a Serde as a tuple of Serializer plus
+  * Deserializer, as well as defining any of those with a [[Function1]] in
+  * the simple case.
+  */
+trait SerdeSyntax {
+
+  implicit def tuple2serde[T](t: (Serializer[T], Deserializer[T])): Serde[T] = {
+    new Serde[T] {
+      override def deserializer(): Deserializer[T] = t._2
+
+      override def serializer(): Serializer[T] = t._1
+
+      override def configure(configs: java.util.Map[String, _],
+                             isKey: Boolean): Unit = {
+        t._1.configure(configs, isKey)
+        t._2.configure(configs, isKey)
+      }
+
+      override def close(): Unit = {
+        t._1.close()
+        t._2.close()
+      }
+    }
+  }
+
+  implicit class FunctionAsSerializer[T](f: T => Array[Byte]) {
+    def asSerializer: Serializer[T] = new Serializer[T] {
+      override def configure(configs: java.util.Map[String, _], isKey: Boolean)
+      : Unit = {}
+
+      override def serialize(topic: String,
+                             data: T): Array[Byte] = {
+        f(data)
+      }
+
+      override def close(): Unit = {}
+    }
+  }
+
+  implicit class OptionalFunctionAsDeserializer[T](f: Array[Byte] => Option[T])
+                                                  (implicit ev: Null <:< T) {
+    def asDeserializer: Deserializer[T] = new Deserializer[T] {
+      override def configure(configs: java.util.Map[String, _], isKey: Boolean)
+      : Unit = {}
+
+      override def close(): Unit = {}
+
+      override def deserialize(topic: String,
+                               data: Array[Byte]): T = {
+        f(data).orNull
+      }
+    }
+  }
+
+  implicit class FunctionAsDeserializer[T](f: Array[Byte] => T) {
+    def asDeserializer: Deserializer[T] = new Deserializer[T] {
+      override def configure(configs: java.util.Map[String, _], isKey: Boolean)
+      : Unit = {}
+
+      override def close(): Unit = {}
+
+      override def deserialize(topic: String,
+                               data: Array[Byte]): T = {
+        f(data)
+      }
+    }
+  }
+
+}
+
+object SerdeSyntax extends SerdeSyntax

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKGroupedStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKGroupedStream.scala
@@ -16,7 +16,7 @@
 package com.lightbend.kafka.scala.streams.typesafe
 
 import com.lightbend.kafka.scala.streams.FunctionConversions._
-import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import com.lightbend.kafka.scala.streams.typesafe.ImplicitConverters._
 import org.apache.kafka.streams.kstream._
 
 /** Wraps the Java class [[KGroupedStream]] and delegates method calls to the

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKGroupedStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKGroupedStream.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import com.lightbend.kafka.scala.streams.FunctionConversions._
+import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import org.apache.kafka.streams.kstream._
+
+/** Wraps the Java class [[KGroupedStream]] and delegates method calls to the
+  * underlying Java object. Makes use of implicit parameters for the
+  * [[util.Materialized]] and [[org.apache.kafka.common.serialization.Serde]]
+  * instances.
+  */
+class TSKGroupedStream[K, V]
+(protected[typesafe] override val unsafe: KGroupedStream[K, V])
+  extends AnyVal with TSKType[KGroupedStream, K, V] {
+
+  def aggregate[VR](initializer: => VR, aggregator: (K, V, VR) => VR)
+                   (implicit materialized: Materialized[K, VR, kvs])
+  : TSKTable[K, VR] =
+    unsafe
+      .aggregate(initializer.asInitializer, aggregator.asAggregator,
+        materialized)
+      .safe
+
+  def count(implicit materialized: Materialized[K, java.lang.Long, kvs])
+  : TSKTable[K, Long] =
+    unsafe
+      .count(materialized)
+      .mapValues[scala.Long](
+      { l: java.lang.Long => Long2long(l) }.asValueMapper)
+      .safe
+
+  def reduce(reducer: (V, V) => V)
+            (implicit materialized: Materialized[K, V, kvs])
+  : TSKTable[K, V] =
+    unsafe
+      .reduce(reducer.asReducer, materialized)
+      .safe
+
+  def windowedBy(windows: SessionWindows)
+  : TSSessionWindowedKStream[K, V] =
+    unsafe
+      .windowedBy(windows)
+      .safe
+
+  def windowedBy[W <: Window](windows: Windows[W])
+  : TSTimeWindowedKStream[K, V] =
+    unsafe
+      .windowedBy(windows)
+      .safe
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKGroupedTable.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKGroupedTable.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import com.lightbend.kafka.scala.streams.FunctionConversions._
+import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import org.apache.kafka.streams.kstream.{KGroupedTable, Materialized}
+
+/** Wraps the Java class [[KGroupedTable]] and delegates method calls to the
+  * underlying Java object. Makes use of implicit parameters for the
+  * [[util.Materialized]] instances.
+  */
+class TSKGroupedTable[K, V]
+(protected[typesafe] override val unsafe: KGroupedTable[K, V])
+  extends AnyVal with TSKType[KGroupedTable, K, V] {
+  def count(implicit materialized: Materialized[K, java.lang.Long, kvs])
+  : TSKTable[K, Long] =
+    unsafe
+      .count(materialized)
+      .mapValues[scala.Long](
+      { l: java.lang.Long => Long2long(l) }.asValueMapper)
+      .safe
+
+  def reduce(adder: (V, V) => V,
+             subtractor: (V, V) => V)
+            (implicit materialized: Materialized[K, V, kvs]): TSKTable[K, V] =
+    unsafe
+      .reduce(adder.asReducer, subtractor.asReducer, materialized)
+      .safe
+
+  def aggregate[VR](initializer: => VR,
+                    adder: (K, V, VR) => VR,
+                    subtractor: (K, V, VR) => VR)
+                   (implicit materialized: Materialized[K, VR, kvs])
+  : TSKTable[K, VR] =
+    unsafe
+      .aggregate(initializer.asInitializer,
+        adder.asAggregator,
+        subtractor.asAggregator,
+        materialized)
+      .safe
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKGroupedTable.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKGroupedTable.scala
@@ -16,7 +16,7 @@
 package com.lightbend.kafka.scala.streams.typesafe
 
 import com.lightbend.kafka.scala.streams.FunctionConversions._
-import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import com.lightbend.kafka.scala.streams.typesafe.ImplicitConverters._
 import org.apache.kafka.streams.kstream.{KGroupedTable, Materialized}
 
 /** Wraps the Java class [[KGroupedTable]] and delegates method calls to the

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKStream.scala
@@ -17,7 +17,7 @@ package com.lightbend.kafka.scala.streams.typesafe
 
 import com.lightbend.kafka.scala.streams.FunctionConversions._
 import com.lightbend.kafka.scala.streams.ImplicitConversions.Tuple2ToKeyValue
-import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import com.lightbend.kafka.scala.streams.typesafe.ImplicitConverters._
 import org.apache.kafka.streams.kstream._
 import org.apache.kafka.streams.processor.{Processor, ProcessorContext,
   ProcessorSupplier}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKStream.scala
@@ -171,6 +171,7 @@ class TSKStream[K, V](protected[typesafe] override val unsafe: KStream[K, V])
           override def init(context: ProcessorContext): Unit =
             transformerS.init(context)
 
+          @deprecated ("Please use Punctuator functional interface at https://kafka.apache.org/10/javadoc/org/apache/kafka/streams/processor/Punctuator.html instead", "0.1.3")
           override def punctuate(timestamp: Long): KeyValue[K1, V1] = {
             val (k1, v1) = transformerS.punctuate(timestamp)
             KeyValue.pair[K1, V1](k1, v1)

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKStream.scala
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import com.lightbend.kafka.scala.streams.FunctionConversions._
+import com.lightbend.kafka.scala.streams.ImplicitConversions.Tuple2ToKeyValue
+import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import org.apache.kafka.streams.kstream._
+import org.apache.kafka.streams.processor.{Processor, ProcessorContext,
+  ProcessorSupplier}
+import org.apache.kafka.streams.{Consumed, KeyValue, StreamsBuilder}
+
+import scala.collection.JavaConverters._
+
+/**
+  * Typesafe KStream implementation. Does not directly allow type-unsafe
+  * operations and every serde is implicitly provided.
+  */
+class TSKStream[K, V](protected[typesafe] override val unsafe: KStream[K, V])
+  extends AnyVal with TSKType[KStream, K, V] {
+
+  def branch(predicates: ((K, V) => Boolean)*): Array[TSKStream[K, V]] = {
+    unsafe.branch(predicates.map(_.asPredicate): _*).map(_.safe)
+  }
+
+  def groupBy[KR](selector: (K, V) => KR)
+                 (implicit serialized: Serialized[KR, V])
+  : TSKGroupedStream[KR, V] =
+    unsafe
+      .groupBy(selector.asKeyValueMapper, serialized)
+      .safe
+
+  def groupByKey(implicit serialized: Serialized[K, V])
+  : TSKGroupedStream[K, V] =
+    unsafe
+      .groupByKey(serialized)
+      .safe
+
+  def join[VO, VR](otherStream: TSKStream[K, VO],
+                   joiner: (V, VO) => VR,
+                   windows: JoinWindows)
+                  (implicit joined: Joined[K, V, VO]): TSKStream[K, VR] =
+    unsafe.join[VO, VR](otherStream.unsafe, joiner.asValueJoiner, windows,
+      joined).safe
+
+  def join[VT, VR](table: TSKTable[K, VT],
+                   joiner: (V, VT) => VR)
+                  (implicit joined: Joined[K, V, VT]): TSKStream[K, VR] =
+    unsafe.join[VT, VR](table.unsafe, joiner.asValueJoiner, joined).safe
+
+  def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV],
+                       keyValueMapper: (K, V) => GK,
+                       joiner: (V, GV) => RV): TSKStream[K, RV] =
+    unsafe
+      .join[GK, GV, RV](globalKTable, keyValueMapper(_, _), joiner(_, _))
+      .safe
+
+  def leftJoin[VO, VR](otherStream: TSKStream[K, VO],
+                       joiner: (V, VO) => VR,
+                       windows: JoinWindows)
+                      (implicit joined: Joined[K, V, VO])
+  : TSKStream[K, VR] =
+    unsafe.leftJoin[VO, VR](
+      otherStream.unsafe,
+      joiner.asValueJoiner,
+      windows,
+      joined)
+      .safe
+
+  def leftJoin[VT, VR](table: TSKTable[K, VT],
+                       joiner: (V, VT) => VR)
+                      (implicit joined: Joined[K, V, VT]): TSKStream[K, VR]
+  = unsafe
+    .leftJoin[VT, VR](table.unsafe, joiner.asValueJoiner, joined)
+    .safe
+
+  def leftJoin[GK, GV, RV](globalKTable: GlobalKTable[GK, GV],
+                           keyValueMapper: (K, V) => GK,
+                           joiner: (V, GV) => RV)
+  : TSKStream[K, RV] =
+    unsafe
+      .leftJoin[GK, GV, RV](
+      globalKTable,
+      keyValueMapper.asKeyValueMapper,
+      joiner.asValueJoiner)
+      .safe
+
+  def outerJoin[VO, VR](otherStream: TSKStream[K, VO],
+                        joiner: (V, VO) => VR,
+                        windows: JoinWindows)
+                       (implicit joined: Joined[K, V, VO])
+  : TSKStream[K, VR] =
+    unsafe
+      .outerJoin[VO, VR](otherStream.unsafe, joiner.asValueJoiner, windows,
+      joined)
+      .safe
+
+  def merge(stream: TSKStream[K, V]): TSKStream[K, V] =
+    unsafe.merge(stream.unsafe).safe
+
+  def peek(action: (K, V) => Unit): TSKStream[K, V] =
+    unsafe.peek(action(_, _)).safe
+
+  def split(predicate: (K, V) => Boolean)
+  : (TSKStream[K, V], TSKStream[K, V]) =
+    (filter(predicate), filterNot(predicate))
+
+  def filter(predicate: (K, V) => Boolean): TSKStream[K, V] =
+    unsafe.filter(predicate.asPredicate).safe
+
+  def filterNot(predicate: (K, V) => Boolean): TSKStream[K, V] =
+    unsafe.filterNot(predicate.asPredicate).safe
+
+  def selectKey[KR](mapper: (K, V) => KR): TSKStream[KR, V] = {
+    unsafe.selectKey[KR]((k: K, v: V) => mapper(k, v)).safe
+  }
+
+  def map[KR, VR](mapper: (K, V) => (KR, VR)): TSKStream[KR, VR] =
+    unsafe.map[KR, VR](mapper.asKeyValueMapper).safe
+
+  def mapValues[VR](mapper: V => VR): TSKStream[K, VR] =
+    unsafe.mapValues[VR](mapper.asValueMapper).safe
+
+  def flatMap[KR, VR](mapper: (K, V) => Iterable[(KR, VR)])
+  : TSKStream[KR, VR] = {
+    val kvMapper = mapper.tupled andThen (iter => iter.map(Tuple2ToKeyValue)
+      .asJava)
+
+    unsafe.flatMap[KR, VR]((k, v) => kvMapper(k, v)).safe
+  }
+
+  def flatMapValues[VR](mapper: V => Iterable[VR]): TSKStream[K, VR] =
+    unsafe.flatMapValues({
+      v: V => mapper(v).asJava
+    }.asValueMapper)
+      .safe
+
+  def filterValues(predicate: V => Boolean): TSKStream[K, V] =
+    unsafe.filter((k, v) => predicate(v)).safe
+
+  def print(printed: Printed[K, V]): Unit = unsafe.print(printed)
+
+  def foreach(action: (K, V) => Unit): Unit =
+    unsafe.foreach((key: K, value: V) => action(key, value))
+
+  def transform[K1, V1](transformerSupplier: => Transformer[K, V, (K1, V1)],
+                        stateStoreNames: String*): TSKStream[K1, V1] = {
+
+    val transformerSupplierJ: TransformerSupplier[K, V, KeyValue[K1, V1]] =
+      () => {
+        val transformerS: Transformer[K, V, (K1, V1)] = transformerSupplier
+        new Transformer[K, V, KeyValue[K1, V1]] {
+          override def transform(key: K, value: V): KeyValue[K1, V1] = {
+            val (k1, v1) = transformerS.transform(key, value)
+            KeyValue.pair(k1, v1)
+          }
+
+          override def init(context: ProcessorContext): Unit =
+            transformerS.init(context)
+
+          override def punctuate(timestamp: Long): KeyValue[K1, V1] = {
+            val (k1, v1) = transformerS.punctuate(timestamp)
+            KeyValue.pair[K1, V1](k1, v1)
+          }
+
+          override def close(): Unit = transformerS.close()
+        }
+      }
+    unsafe
+      .transform(transformerSupplierJ, stateStoreNames: _*)
+      .safe
+  }
+
+  def transformValues[VR](valueTransformerSupplier: () => ValueTransformer[V,
+    VR],
+                          stateStoreNames: String*): TSKStream[K, VR] = {
+    val valueTransformerSupplierJ: ValueTransformerSupplier[V, VR] = () =>
+      valueTransformerSupplier()
+    unsafe
+      .transformValues[VR](valueTransformerSupplierJ, stateStoreNames: _*)
+      .safe
+  }
+
+  def process(processorSupplier: () => Processor[K, V],
+              stateStoreNames: String*): Unit = {
+    val processorSupplierJ: ProcessorSupplier[K, V] = () => processorSupplier()
+    unsafe
+      .process(processorSupplierJ, stateStoreNames: _*)
+  }
+
+  def through(topic: String)
+             (implicit produced: Produced[K, V]): TSKStream[K, V] =
+    unsafe
+      .through(topic, produced)
+      .safe
+
+  def to(topic: String)(implicit produced: Produced[K, V]): Unit = {
+    unsafe.to(topic, produced)
+  }
+}
+
+object TSKStream {
+  /** Creates a new TSKStream from a topic, given an implicit StreamsBuilder
+    * and the appropriate Serde instances for the types you want to read from
+    * the topic.
+    *
+    * @param topic the topic name you want to read from
+    * @param builder the StreamsBuilder you want to use
+    * @param consumed the Consumed instance that contains the deserialization
+    *                 procedure from the Kafka topic
+    * @tparam K the type of keys to be read from the topic
+    * @tparam V the type of values to be read from the topic
+    * @return
+    */
+  def apply[K, V](topic: String)
+                 (implicit builder: StreamsBuilder,
+                  consumed: Consumed[K, V]): TSKStream[K, V] =
+    new TSKStream[K, V](builder.stream(topic, consumed))
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKTable.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKTable.scala
@@ -16,11 +16,9 @@
 package com.lightbend.kafka.scala.streams.typesafe
 
 import com.lightbend.kafka.scala.streams.FunctionConversions._
-import com.lightbend.kafka.scala.streams.typesafe.implicits._
-import org.apache.kafka.streams.{Consumed, StreamsBuilder}
+import com.lightbend.kafka.scala.streams.typesafe.ImplicitConverters._
 import org.apache.kafka.streams.kstream.{KTable, Materialized, Serialized}
-
-import scala.language.higherKinds
+import org.apache.kafka.streams.{Consumed, StreamsBuilder}
 
 class TSKTable[K, V](protected[typesafe] override val unsafe: KTable[K, V])
   extends AnyVal with TSKType[KTable, K, V] {

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKTable.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKTable.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import com.lightbend.kafka.scala.streams.FunctionConversions._
+import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import org.apache.kafka.streams.{Consumed, StreamsBuilder}
+import org.apache.kafka.streams.kstream.{KTable, Materialized, Serialized}
+
+import scala.language.higherKinds
+
+class TSKTable[K, V](protected[typesafe] override val unsafe: KTable[K, V])
+  extends AnyVal with TSKType[KTable, K, V] {
+
+  def map[KR, VR](selector: (K, V) => (KR, VR))
+                 (implicit serialized: Serialized[KR, VR])
+  : TSKGroupedTable[KR, VR] =
+    unsafe
+      .groupBy(selector.asKeyValueMapper, serialized)
+      .safe
+
+  def mapValues[VR](mapper: V => VR)
+                   (implicit materialized: Materialized[K, VR, kvs])
+  : TSKTable[K, VR] =
+    unsafe
+      .mapValues[VR](mapper.asValueMapper, materialized)
+      .safe
+
+  def filterValues(predicate: V => Boolean)
+                  (implicit materialized: Materialized[K, V, kvs])
+  : TSKTable[K, V] = this.filter((k, v) => predicate(v))
+
+  def filter(predicate: (K, V) => Boolean)
+            (implicit materialized: Materialized[K, V, kvs])
+  : TSKTable[K, V] =
+    unsafe
+      .filter(predicate.asPredicate, materialized)
+      .safe
+
+  def filterNot(predicate: (K, V) => Boolean)
+               (implicit materialized: Materialized[K, V, kvs])
+  : TSKTable[K, V] =
+    unsafe
+      .filterNot(predicate.asPredicate, materialized)
+      .safe
+
+  def toStream: TSKStream[K, V] = unsafe.toStream.safe
+
+  def toStream[KR](keyMapper: (K, V) => KR): TSKStream[KR, V] =
+    unsafe
+      .toStream[KR](keyMapper.asKeyValueMapper)
+      .safe
+
+  def groupBy[KR, VR](selector: (K, V) => (KR, VR))
+                     (implicit serialized: Serialized[KR, VR])
+  : TSKGroupedTable[KR, VR]
+  = unsafe
+    .groupBy(selector.asKeyValueMapper, serialized)
+    .safe
+
+  def join[VO, VR](other: TSKTable[K, VO],
+                   joiner: (V, VO) => VR)
+                  (implicit materialized: Materialized[K, VR, kvs])
+  : TSKTable[K, VR] =
+    unsafe
+      .join[VO, VR](other.unsafe, joiner.asValueJoiner, materialized)
+      .safe
+
+  def leftJoin[VO, VR](other: TSKTable[K, VO],
+                       joiner: (V, VO) => VR)
+                      (implicit materialized: Materialized[K, VR, kvs])
+  : TSKTable[K, VR] =
+    unsafe
+      .leftJoin[VO, VR](other.unsafe, joiner.asValueJoiner, materialized)
+      .safe
+
+  def outerJoin[VO, VR](other: TSKTable[K, VO],
+                        joiner: (V, VO) => VR)
+                       (implicit materialized: Materialized[K, VR, kvs])
+  : TSKTable[K, VR] =
+    unsafe
+      .outerJoin[VO, VR](other.unsafe, joiner.asValueJoiner, materialized)
+      .safe
+
+  def queryableStoreName: String = unsafe.queryableStoreName()
+
+}
+
+object TSKTable {
+  /** Creates a new TSKStream from a topic, given an implicit StreamsBuilder
+    * and the appropriate Serde instances for the types you want to read from
+    * the topic.
+    *
+    * @param topic the topic name you want to read from
+    * @param builder the StreamsBuilder you want to use
+    * @param consumed the Consumed instance that contains the deserialization
+    *                 procedure from the Kafka topic
+    * @tparam K the type of keys to be read from the topic
+    * @tparam V the type of values to be read from the topic
+    * @return
+    */
+  def apply[K, V](topic: String)
+                 (implicit builder: StreamsBuilder,
+                  consumed: Consumed[K, V]): TSKTable[K, V] =
+    new TSKTable[K, V](builder.table(topic, consumed))
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKType.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSKType.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import scala.language.higherKinds
+
+/** A base type for all base stream classes in the typesafe API.
+  */
+trait TSKType[T[_, _], K, V] extends Any {
+  protected[typesafe] def unsafe: T[K, V]
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSSessionWindowedKStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSSessionWindowedKStream.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import com.lightbend.kafka.scala.streams.FunctionConversions._
+import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import org.apache.kafka.streams.kstream.{Materialized,
+  SessionWindowedKStream, Windowed}
+
+class TSSessionWindowedKStream[K, V]
+(protected[typesafe] override val unsafe: SessionWindowedKStream[K, V])
+  extends AnyVal with TSKType[SessionWindowedKStream, K, V] {
+
+  def aggregate[VR](initializer: => VR,
+                    aggregator: (K, V, VR) => VR,
+                    merger: (K, VR, VR) => VR)
+                   (implicit materialized: Materialized[K, VR, ssb])
+  : TSKTable[Windowed[K], VR] = {
+    unsafe.aggregate(
+      initializer.asInitializer,
+      aggregator.asAggregator,
+      merger.asMerger,
+      materialized)
+      .safe
+  }
+
+  def count(implicit materialized: Materialized[K, java.lang.Long, ssb])
+  : TSKTable[Windowed[K], Long] =
+    unsafe
+      .count(materialized)
+      .mapValues[scala.Long]({
+      l: java.lang.Long => Long2long(l)
+    }.asValueMapper).safe
+
+
+  def reduce(reducer: (V, V) => V)
+            (implicit materialized: Materialized[K, V, ssb])
+  : TSKTable[Windowed[K], V] = {
+    unsafe.reduce(reducer.asReducer, materialized).safe
+  }
+
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSSessionWindowedKStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSSessionWindowedKStream.scala
@@ -16,7 +16,7 @@
 package com.lightbend.kafka.scala.streams.typesafe
 
 import com.lightbend.kafka.scala.streams.FunctionConversions._
-import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import com.lightbend.kafka.scala.streams.typesafe.ImplicitConverters._
 import org.apache.kafka.streams.kstream.{Materialized,
   SessionWindowedKStream, Windowed}
 

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSTimeWindowedKStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSTimeWindowedKStream.scala
@@ -16,7 +16,7 @@
 package com.lightbend.kafka.scala.streams.typesafe
 
 import com.lightbend.kafka.scala.streams.FunctionConversions._
-import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import com.lightbend.kafka.scala.streams.typesafe.ImplicitConverters._
 import org.apache.kafka.streams.kstream.{Materialized, TimeWindowedKStream,
   Windowed}
 

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSTimeWindowedKStream.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/TSTimeWindowedKStream.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import com.lightbend.kafka.scala.streams.FunctionConversions._
+import com.lightbend.kafka.scala.streams.typesafe.implicits._
+import org.apache.kafka.streams.kstream.{Materialized, TimeWindowedKStream,
+  Windowed}
+
+class TSTimeWindowedKStream[K, V]
+(protected[typesafe] override val unsafe: TimeWindowedKStream[K, V])
+  extends AnyVal with TSKType[TimeWindowedKStream, K, V] {
+
+  def aggregate[VR](initializer: => VR,
+                    aggregator: (K, V, VR) => VR)
+                   (implicit materialized: Materialized[K, VR, wsb])
+  : TSKTable[Windowed[K], VR] = {
+    unsafe.aggregate(initializer.asInitializer,
+      aggregator.asAggregator,
+      materialized)
+      .safe
+  }
+
+  def count(implicit materialized: Materialized[K, java.lang.Long, wsb])
+  : TSKTable[Windowed[K], Long] = {
+    unsafe
+      .count(materialized)
+      .mapValues[scala.Long]({
+      l: java.lang.Long => Long2long(l)
+    }.asValueMapper).safe
+  }
+
+  def reduce(reducer: (V, V) => V)
+            (implicit materialized: Materialized[K, V, wsb])
+  : TSKTable[Windowed[K], V] = {
+    unsafe
+      .reduce(reducer.asReducer, materialized)
+      .safe
+  }
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/derivations/package.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/derivations/package.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import java.nio.ByteBuffer
+
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams.Consumed
+import org.apache.kafka.streams.kstream.{Joined, Materialized, Produced,
+  Serialized}
+import org.apache.kafka.streams.processor.StateStore
+
+/** Many default derivations, provided as standalone universal traits that
+  * can be mixed in anywhere.
+  *
+  * Also provides a [[derivations.Default]] object that can be used directly
+  * extending all these mix-in traits.
+  */
+package object derivations {
+
+  trait materialized extends Any {
+    implicit def materializedFromSerdes[K, V, S <: StateStore]
+    (implicit key: Serde[K], value: Serde[V]): Materialized[K, V, S] = {
+      util.Materialized[K, V]
+    }
+  }
+
+  trait serialized extends Any {
+    implicit def serializedFromSerdes[K, V](implicit key: Serde[K],
+                                            value: Serde[V])
+    : Serialized[K, V] = {
+      Serialized.`with`(key, value)
+    }
+  }
+
+  trait produced extends Any {
+    implicit def producedFromSerdes[K, V](implicit key: Serde[K],
+                                          value: Serde[V])
+    : Produced[K, V] = {
+      Produced.`with`(key, value)
+    }
+  }
+
+  trait consumed extends Any {
+    implicit def consumedFromSerdes[K, V](implicit key: Serde[K],
+                                          value: Serde[V])
+    : Consumed[K, V] = {
+      Consumed.`with`(key, value)
+    }
+  }
+
+  trait joined extends Any {
+    implicit def joinedFromSerdes[K, V, VO](implicit key: Serde[K],
+                                            value: Serde[V], value2: Serde[VO])
+    : Joined[K, V, VO] = {
+      Joined.`with`(key, value, value2)
+    }
+  }
+
+  trait defaultSerdes {
+    implicit val ScalaLongSerde: Serde[Long] =
+      Serdes.Long().asInstanceOf[Serde[Long]]
+
+    implicit val ScalaDoubleSerde: Serde[Double] =
+      Serdes.Double().asInstanceOf[Serde[Double]]
+
+    implicit val stringSerde: Serde[String] = Serdes.String()
+    implicit val javaLongSerde: Serde[java.lang.Long] = Serdes.Long()
+    implicit val javaFloatSerde: Serde[java.lang.Float] = Serdes.Float()
+    implicit val javaDoubleSerde: Serde[java.lang.Double] = Serdes.Double()
+    implicit val byteArraySerde: Serde[Array[Byte]] = Serdes.ByteArray()
+    implicit val byteBufferSerde: Serde[ByteBuffer] = Serdes.ByteBuffer()
+  }
+
+  trait Default
+    extends serialized
+      with produced
+      with consumed
+      with joined
+      with materialized
+      with defaultSerdes
+
+  object Default extends Default
+
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/derivations/package.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/derivations/package.scala
@@ -71,10 +71,10 @@ package object derivations {
   }
 
   trait defaultSerdes {
-    implicit val ScalaLongSerde: Serde[Long] =
+    implicit val scalaLongSerde: Serde[Long] =
       Serdes.Long().asInstanceOf[Serde[Long]]
 
-    implicit val ScalaDoubleSerde: Serde[Double] =
+    implicit val scalaDoubleSerde: Serde[Double] =
       Serdes.Double().asInstanceOf[Serde[Double]]
 
     implicit val stringSerde: Serde[String] = Serdes.String()

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/implicits.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/implicits.scala
@@ -1,0 +1,59 @@
+package com.lightbend.kafka.scala.streams.typesafe
+
+import org.apache.kafka.streams.kstream._
+
+/** Conversions to keep the underlying abstraction from leaking. These allow
+  * us to always return a TS object instead of the underlying one.
+  *
+  * These conversions are all Value Classes (extends AnyVal), which means
+  * that no new objects get allocated for the `.safe` call (only the TSxx
+  * objects get allocated).
+  *
+  * @author Santiago Saavedra (ssaavedra@openshine.com)
+  */
+private[typesafe] object implicits {
+
+  implicit final class TSKStreamAuto[K, V]
+  (val inner: KStream[K, V])
+    extends
+      AnyVal {
+    def safe: TSKStream[K, V] =
+      new TSKStream[K, V](inner)
+  }
+
+  implicit final class TSKTableAuto[K, V]
+  (val inner: KTable[K, V])
+    extends AnyVal {
+    def safe: TSKTable[K, V] =
+      new TSKTable[K, V](inner)
+  }
+
+  implicit final class TSKGroupedStreamAuto[K, V]
+  (val inner: KGroupedStream[K, V])
+    extends AnyVal {
+    def safe: TSKGroupedStream[K, V] =
+      new TSKGroupedStream[K, V](inner)
+  }
+
+  implicit final class TSKGroupedTableAuto[K, V]
+  (val inner: KGroupedTable[K, V])
+    extends AnyVal {
+    def safe: TSKGroupedTable[K, V] =
+      new TSKGroupedTable[K, V](inner)
+  }
+
+  implicit final class TSSessionWindowedKStreamAuto[K, V]
+  (val inner: SessionWindowedKStream[K, V])
+    extends AnyVal {
+    def safe: TSSessionWindowedKStream[K, V] =
+      new TSSessionWindowedKStream[K, V](inner)
+  }
+
+  implicit final class TSTimeWindowedKStreamAuto[K, V]
+  (val inner: TimeWindowedKStream[K, V])
+    extends AnyVal {
+    def safe: TSTimeWindowedKStream[K, V] =
+      new TSTimeWindowedKStream[K, V](inner)
+  }
+
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/implicits.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/implicits.scala
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.lightbend.kafka.scala.streams.typesafe
 
+import com.lightbend.kafka.scala.streams.typesafe.unsafe.ConverterToTypeSafer
 import org.apache.kafka.streams.kstream._
 
 /** Conversions to keep the underlying abstraction from leaking. These allow
@@ -8,8 +25,6 @@ import org.apache.kafka.streams.kstream._
   * These conversions are all Value Classes (extends AnyVal), which means
   * that no new objects get allocated for the `.safe` call (only the TSxx
   * objects get allocated).
-  *
-  * @author Santiago Saavedra (ssaavedra@openshine.com)
   */
 private[typesafe] object implicits {
 
@@ -54,6 +69,41 @@ private[typesafe] object implicits {
     extends AnyVal {
     def safe: TSTimeWindowedKStream[K, V] =
       new TSTimeWindowedKStream[K, V](inner)
+  }
+
+  implicit object TSKGroupedStreamAuto
+    extends ConverterToTypeSafer[KGroupedStream, TSKGroupedStream] {
+    override def safe[K, V](src: KGroupedStream[K, V]): TSKGroupedStream[K, V] =
+      src.safe
+  }
+
+  implicit object TSKStreamAuto
+    extends ConverterToTypeSafer[KStream, TSKStream] {
+    override def safe[K, V](src: KStream[K, V]): TSKStream[K, V] = src.safe
+  }
+
+  implicit object TSKTableAuto
+    extends ConverterToTypeSafer[KTable, TSKTable] {
+    override def safe[K, V](src: KTable[K, V]): TSKTable[K, V] = src.safe
+  }
+
+  implicit object TSKGroupedTableAuto
+    extends ConverterToTypeSafer[KGroupedTable, TSKGroupedTable] {
+    override def safe[K, V](src: KGroupedTable[K, V])
+    : TSKGroupedTable[K, V] = src.safe
+  }
+
+  implicit object TSSessionWindowedKStreamAuto
+    extends ConverterToTypeSafer[SessionWindowedKStream,
+      TSSessionWindowedKStream] {
+    override def safe[K, V](src: SessionWindowedKStream[K, V])
+    : TSSessionWindowedKStream[K, V] = src.safe
+  }
+
+  implicit object TSTimeWindowedKStreamAuto
+    extends ConverterToTypeSafer[TimeWindowedKStream, TSTimeWindowedKStream] {
+    override def safe[K, V](src: TimeWindowedKStream[K, V])
+    : TSTimeWindowedKStream[K, V] = src.safe
   }
 
 }

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/package.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/package.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams
+
+import org.apache.kafka.common.utils.Bytes
+import org.apache.kafka.streams.state.{KeyValueStore, SessionStore, WindowStore}
+
+/** Provides a more type-safe interface for Kafka Streams when using Scala.
+  *
+  * In particular, it always requires a Materialized instance to be provided
+  * to aggregating functions that may persist data, so that you won't ever
+  * find yourself using the default Serde and thus converting runtime
+  * exceptions in compile-time errors.
+  *
+  * You don't need to create all Materialized (and other persisting helper)
+  * objects, as they can be deduced by the Scala type system when you have
+  * the implicit resolution rules available at
+  * [[com.lightbend.kafka.scala.streams.typesafe.SerdeDerivations]] in scope.
+  *
+  */
+package object typesafe {
+  private[typesafe] type kvs = KeyValueStore[Bytes, Array[Byte]]
+  private[typesafe] type ssb = SessionStore[Bytes, Array[Byte]]
+  private[typesafe] type wsb = WindowStore[Bytes, Array[Byte]]
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/unsafe.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/unsafe.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.kafka.scala.streams.typesafe
+
+import scala.language.higherKinds
+
+/** Unsafe operations enabler.
+  *
+  * When introducing this object into scope you will gain access to
+  * [[com.lightbend.kafka.scala.streams.typesafe.unsafe.UnsafelyWrapper]] which
+  * enables the `unsafely` definition. You may use that to tap into the
+  * underlying `unsafe` value and always retrieve a wrapped safe value back.
+  *
+  * In order not to break encapsulation, if you need to output values that
+  * are outside the provided library, you will have to provide a
+  * [[com.lightbend.kafka.scala.streams.typesafe!.ConverterToTypeSafer]]
+  * instance providing a conversion from Src to the safe Dst.
+  */
+object unsafe {
+
+  trait ConverterToTypeSafer[-Src[K, V], +Dst[K, V]] {
+    def safe[K, V](src: Src[K, V]): Dst[K, V]
+  }
+
+  /** This class provides `.unsafely` instances for
+    * [[com.lightbend.kafka.scala.streams.typesafe.TSKType]] values that may be
+    * needed to provide values that cannot be assumed to be type-safe. You
+    * can also use the `.unsafelyNoWrap` construct which does not wrap the
+    * returned type (and thus you will have an abstraction leak, but you
+    * needn't provide the type conversion).
+    *
+    * @param inner the TSKType that is being unsafely handled
+    * @tparam KType the underlying implementation type (A KStream/KTable/etc)
+    * @tparam K     the type of the key for this TSKType
+    * @tparam V     the type of values for this TSKType
+    */
+  implicit class UnsafelyWrapper[KType[_, _], K, V]
+  (private val inner: TSKType[KType, K, V])
+  extends AnyVal {
+
+    /** Allows the user to perform potentially-unsafe operations with the
+      * TSKType, which may be usesful for accessing properties not yet
+      * implemented on this library.
+      *
+      * Take note that in order not to leak the type-unsound abstraction you
+      * must provide a [[ConverterToTypeSafer]] which should wrap the
+      * value of `transformer` into its returned type. Your provided function
+      * should operate only on the underlying types.
+      *
+      * Take note that it is assumed as of now that your operation will
+      * return a (*, *)-kind type, with "holes" for a resulting key and value.
+      * If you can't operate under such constraint, you will need to rely on
+      * [[unsafelyNoWrap()]] for the moment.
+      *
+      * @param transformer the function that transforms the inner type
+      * @param wrap        the evidence used to wrap the transformer output
+      *                    back to a typesafe value (needn't be a TSKType, so
+      *                    you can implement your own conversions)
+      * @tparam K1        the resulting key type
+      * @tparam V1        the resulting value type
+      * @tparam UnsafeDst the type returned by the transformer, which is a
+      *                   raw type in the underlying implementation
+      * @tparam SafeDst   the type that should be returned after performing the
+      *                   unsafe operation and which should wrap the type
+      *                   returned by the transformer in a more
+      *                   type-constrained way
+      * @return a SafeDst value that has been transformed by the transformer
+      *         on its underlying values
+      */
+    def unsafely[K1, V1, UnsafeDst[_, _], SafeDst[_, _]]
+    (transformer: KType[K, V] => UnsafeDst[K1, V1])
+    (implicit wrap: ConverterToTypeSafer[UnsafeDst, SafeDst])
+    : SafeDst[K1, V1] = wrap.safe(transformer(inner.unsafe))
+
+    /** Allows the user to perform potentially-unsafe operations with the
+      * TSKType. Take note that this abstraction leaks Dst to the callee.
+      *
+      * @param transformer the transformation to apply to the underlying type
+      * @tparam Dst the type of the result of the transformation
+      * @return the result of the transformation
+      */
+    def unsafelyNoWrap[Dst](transformer: KType[K, V] => Dst) =
+      transformer(inner.unsafe)
+  }
+
+}

--- a/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/util/Materialized.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/typesafe/util/Materialized.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 OpenShine SL <https://www.openshine.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.kafka.scala.streams.typesafe.util
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.streams.kstream.{Materialized => Base}
+import org.apache.kafka.streams.processor.StateStore
+
+import scala.language.implicitConversions
+
+/** Convenience object for creating Materialized objects from Scala.
+  *
+  * You can create a materialized from (implicit or explicit) Serde instances
+  * by calling .apply as such:
+  * {{{
+  *   Materialized[String, MyType]
+  * }}}
+  *
+  * You can also name your Materialized by using [[Materialized.as()]], with
+  * these two syntaxes:
+  *
+  * {{{
+  *   Materialized[String, MyType].as[WindowStore]("Hello world")
+  *
+  *   Materialized.as[String, MyType, WindowStore]("Hello world")
+  * }}}
+  *
+  * The third type parameter may not be required in cases where it can be
+  * inferred by the Scala type system, but is provided in the example for
+  * completeness.
+  */
+object Materialized {
+  def apply[K, V](implicit keySerde: Serde[K],
+                  valueSerde: Serde[V]): MaterializedBuilder[K, V] = {
+    new MaterializedBuilder(keySerde, valueSerde)
+  }
+
+  def as[K, V, S <: StateStore](stateStoreName: String)
+                               (implicit keySerde: Serde[K],
+                                valueSerde: Serde[V]): Base[K, V, S] = {
+    Base.as(stateStoreName).withKeySerde(keySerde).withValueSerde(valueSerde)
+  }
+
+  class MaterializedBuilder[K, V](val keySerde: Serde[K],
+                                  val valueSerde: Serde[V]) {
+    def as[S <: StateStore](stateStoreName: String): Base[K, V, S] =
+      Base.as(stateStoreName).withKeySerde(keySerde).withValueSerde(valueSerde)
+
+  }
+
+  implicit def builderAsBase[K, V, S <: StateStore]
+  (builder: MaterializedBuilder[K, V]): Base[K, V, S] =
+    Base.`with`(builder.keySerde, builder.valueSerde)
+
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/KafkaStreamsTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/KafkaStreamsTest.scala
@@ -1,0 +1,122 @@
+/**
+  * Copyright (C) 2018 OpenShine SL <https://www.openshine.com>
+  * Copyright (C) 2018  <https://www.lightbend.com>
+  * Adapted from the parent package
+  */
+
+package com.lightbend.kafka.scala.streams.typesafe
+
+import java.util.Properties
+import java.util.regex.Pattern
+
+import com.lightbend.kafka.scala.server.{KafkaLocalServer, MessageListener, MessageSender, RecordProcessorTrait}
+import minitest.TestSuite
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsBuilder, StreamsConfig}
+
+object KafkaStreamsTest extends TestSuite[KafkaLocalServer] with WordCountTestData {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count words") { server =>
+
+    server.createTopic(inputTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+
+    val streamsConfiguration = new Properties()
+    streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, s"wordcount-${scala.util.Random.nextInt(100)}")
+    streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, "wordcountgroup")
+
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+    streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+
+    import SerdeDerivations._
+    implicit val builder = new StreamsBuilder()
+
+    val textLines = TSKStream[String, String](inputTopic)
+
+    val pattern = Pattern.compile("\\W+", Pattern.UNICODE_CHARACTER_CLASS)
+
+    val wordCounts: TSKTable[String, Long] =
+      textLines.flatMapValues(v => pattern.split(v.toLowerCase))
+        .groupBy((k, v) => v)
+        .count
+
+    wordCounts.toStream.to(outputTopic)
+
+    val streams = new KafkaStreams(builder.build, streamsConfiguration)
+    streams.start()
+
+    //
+    // Step 2: Produce some input data to the input topic.
+    //
+    val sender = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName)
+    val mvals = sender.batchWriteValue(inputTopic, inputValues)
+
+    //
+    // Step 3: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "wordcountgroup",
+      classOf[StringDeserializer].getName,
+      classOf[LongDeserializer].getName,
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedWordCounts.size, 30000)
+
+    assertEquals(l.sortBy(_.key), expectedWordCounts.sortBy(_.key))
+
+    streams.close()
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = {
+      // println(s"Get Message $record")
+    }
+  }
+
+}
+
+trait WordCountTestData {
+  val inputTopic = s"inputTopic.${scala.util.Random.nextInt(100)}"
+  val outputTopic = s"outputTopic.${scala.util.Random.nextInt(100)}"
+  val brokers = "localhost:9092"
+  val localStateDir = "local_state_data"
+
+  val inputValues = List(
+    "Hello Kafka Streams",
+    "All streams lead to Kafka",
+    "Join Kafka Summit",
+    "И теперь пошли русские слова"
+  )
+
+  val expectedWordCounts: List[KeyValue[String, Long]] = List(
+    new KeyValue("hello", 1L),
+    new KeyValue("all", 1L),
+    new KeyValue("streams", 2L),
+    new KeyValue("lead", 1L),
+    new KeyValue("to", 1L),
+    new KeyValue("join", 1L),
+    new KeyValue("kafka", 3L),
+    new KeyValue("summit", 1L),
+    new KeyValue("и", 1L),
+    new KeyValue("теперь", 1L),
+    new KeyValue("пошли", 1L),
+    new KeyValue("русские", 1L),
+    new KeyValue("слова", 1L)
+  )
+}
+

--- a/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/ProbabilisticCountingScalaIntegrationTest.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/ProbabilisticCountingScalaIntegrationTest.scala
@@ -1,0 +1,178 @@
+/**
+  * Copyright (C) 2018 OpenShine SL <https://www.openshine.com>
+  * Copyright (C) 2018  <https://www.lightbend.com>
+  * Adapted from the parent package
+  */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import java.util.Properties
+
+import com.lightbend.kafka.scala.server.{KafkaLocalServer, MessageListener, MessageSender, RecordProcessorTrait}
+import com.lightbend.kafka.scala.streams.algebird.{CMSStore, CMSStoreBuilder}
+import minitest.TestSuite
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams.kstream.Transformer
+import org.apache.kafka.streams.processor.ProcessorContext
+import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsBuilder, StreamsConfig}
+import com.lightbend.kafka.scala.streams.ImplicitConversions.Tuple2ToKeyValue
+
+/**
+  * End-to-end integration test that demonstrates how to probabilistically count items in an input stream.
+  *
+  * This example uses a custom state store implementation, [[CMSStore]], that is backed by a
+  * Count-Min Sketch data structure.
+  */
+trait ProbabilisticCountingScalaIntegrationTestData {
+  val brokers = "localhost:9092"
+  val inputTopic = s"inputTopic.${scala.util.Random.nextInt(100)}"
+  val outputTopic = s"output-topic.${scala.util.Random.nextInt(100)}"
+  val localStateDir = "local_state_data"
+
+  val inputTextLines: Seq[String] = Seq(
+    "Hello Kafka Streams",
+    "All streams lead to Kafka",
+    "Join Kafka Summit"
+  )
+
+  val expectedWordCounts: Seq[KeyValue[String, Long]] = Seq(
+    ("hello", 1L),
+    ("kafka", 1L),
+    ("streams", 1L),
+    ("all", 1L),
+    ("streams", 2L),
+    ("lead", 1L),
+    ("to", 1L),
+    ("kafka", 2L),
+    ("join", 1L),
+    ("kafka", 3L),
+    ("summit", 1L)
+  )
+}
+
+object ProbabilisticCountingScalaIntegrationTest extends TestSuite[KafkaLocalServer]
+  with ProbabilisticCountingScalaIntegrationTestData {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("shouldProbabilisticallyCountWords") { server =>
+
+    server.createTopic(inputTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p.put(StreamsConfig.APPLICATION_ID_CONFIG, s"probabilistic-counting-scala-integration-test-${scala.util.Random.nextInt(100)}")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "10000")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+      p
+    }
+
+    import SerdeDerivations._
+    implicit val builder = new StreamsBuilder()
+
+    val cmsStoreName = "cms-store"
+    val cmsStoreBuilder = {
+      val changeloggingEnabled = true
+      val changelogConfig: java.util.HashMap[String, String] = {
+        val cfg = new java.util.HashMap[String, String]
+        val segmentSizeBytes = (20 * 1024 * 1024).toString
+        cfg.put("segment.bytes", segmentSizeBytes)
+        cfg
+      }
+      new CMSStoreBuilder[String](cmsStoreName, Serdes.String())
+        .withLoggingEnabled(changelogConfig)
+    }
+    builder.addStateStore(cmsStoreBuilder)
+
+    class ProbabilisticCounter extends Transformer[Array[Byte], String, (String, Long)] {
+
+      private var cmsState: CMSStore[String] = _
+      private var processorContext: ProcessorContext = _
+
+      override def init(processorContext: ProcessorContext): Unit = {
+        this.processorContext = processorContext
+        cmsState = this.processorContext.getStateStore(cmsStoreName).asInstanceOf[CMSStore[String]]
+      }
+
+      override def transform(key: Array[Byte], value: String): (String, Long) = {
+        // Count the record value, think: "+ 1"
+        cmsState.put(value, this.processorContext.timestamp())
+
+        // In this example: emit the latest count estimate for the record value.  We could also do
+        // something different, e.g. periodically output the latest heavy hitters via `punctuate`.
+        (value, cmsState.get(value))
+      }
+
+      override def punctuate(l: Long): (String, Long) = null
+
+      override def close(): Unit = {}
+    }
+
+    // Read the input from Kafka.
+    val textLines: TSKStream[Array[Byte], String] = TSKStream[Array[Byte], String](inputTopic)
+
+    textLines
+      .flatMapValues(value => value.toLowerCase.split("\\W+").toIterable)
+      .transform(new ProbabilisticCounter, cmsStoreName)
+      .to(outputTopic)
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration)
+    streams.start()
+
+    //
+    // Step 2: Publish some input text lines.
+    //
+    val sender = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName)
+    val mvals = sender.batchWriteValue(inputTopic, inputTextLines)
+
+    //
+    // Step 3: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "probwordcountgroup",
+      classOf[StringDeserializer].getName,
+      classOf[LongDeserializer].getName,
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedWordCounts.size, 30000)
+
+    assertEquals(l.sortBy(_.key), expectedWordCounts.sortBy(_.key))
+    streams.close()
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = {
+      // println(s"Get Message $record")
+    }
+  }
+
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2018 OpenShine SL <https://www.openshine.com>
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Adapted from Confluent Inc. whose copyright is reproduced below.
+ */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import java.util.Properties
+
+import com.lightbend.kafka.scala.server.{KafkaLocalServer, MessageListener, MessageSender, RecordProcessorTrait}
+import com.lightbend.kafka.scala.streams.StreamToTableJoinTestData
+import minitest.TestSuite
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
+
+/**
+  * End-to-end integration test that demonstrates how to perform a join between a KStream and a
+  * KTable (think: KStream.leftJoin(KTable)), i.e. an example of a stateful computation.
+  *
+  * See StreamToTableJoinIntegrationTest for the equivalent Java example.
+  *
+  * Note: We intentionally use JUnit4 (wrapped by ScalaTest) for implementing this Scala integration
+  * test so it is easier to compare this Scala code with the equivalent Java code at
+  * StreamToTableJoinIntegrationTest.  One difference is that, to simplify the Scala/Junit integration, we
+  * switched from BeforeClass (which must be `static`) to Before as well as from @ClassRule (which
+  * must be `static` and `public`) to a workaround combination of `@Rule def` and a `private val`.
+  */
+
+object StreamToTableJoinScalaIntegrationTestImplicitSerdes extends TestSuite[KafkaLocalServer] with StreamToTableJoinTestData {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count clicks per region") { server =>
+
+    server.createTopic(userClicksTopic)
+    server.createTopic(userRegionsTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p.put(StreamsConfig.APPLICATION_ID_CONFIG, s"stream-table-join-scala-integration-test-implicit-serdes-${scala.util.Random.nextInt(100)}")
+      p.put(StreamsConfig.CLIENT_ID_CONFIG, "join-scala-integration-test-implicit-serdes-standard-consumer")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+      p
+    }
+
+    import SerdeDerivations._
+    implicit val builder = new StreamsBuilder()
+
+    val userClicksStream: TSKStream[String, Long] = TSKStream(userClicksTopic)
+
+    val userRegionsTable: TSKTable[String, String] = TSKTable(userRegionsTopic)
+
+    // Compute the total per region by summing the individual click counts per region.
+    val clicksPerRegion: TSKTable[String, Long] =
+      userClicksStream
+
+        // Join the stream against the table.
+        .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
+
+        // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+        .map((_, regionWithClicks) => regionWithClicks)
+
+        // Compute the total per region by summing the individual click counts per region.
+        .groupByKey
+        .reduce(_ + _)
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic)
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build, streamsConfiguration)
+
+    streams.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      override def uncaughtException(t: Thread, e: Throwable): Unit = try {
+        println(s"Stream terminated because of uncaught exception .. Shutting down app", e)
+        e.printStackTrace
+        val closed = streams.close()
+        println(s"Exiting application after streams close ($closed)")
+      } catch {
+        case x: Exception => x.printStackTrace
+      } finally {
+        println("Exiting application ..")
+        System.exit(-1)
+      }
+    })
+
+    streams.start()
+
+    //
+    // Step 2: Publish user-region information.
+    //
+    // To keep this code example simple and easier to understand/reason about, we publish all
+    // user-region records before any user-click records (cf. step 3).  In practice though,
+    // data records would typically be arriving concurrently in both input streams/topics.
+    val sender1 = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName) 
+    userRegions.foreach(r => sender1.writeKeyValue(userRegionsTopic, r.key, r.value))
+
+    //
+    // Step 3: Publish some user click events.
+    //
+    val sender2 = MessageSender[String, Long](brokers, classOf[StringSerializer].getName, classOf[LongSerializer].getName) 
+    userClicks.foreach(r => sender2.writeKeyValue(userClicksTopic, r.key, r.value))
+
+    //
+    // Step 4: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "join-scala-integration-test-standard-consumer", 
+      classOf[StringDeserializer].getName, 
+      classOf[LongDeserializer].getName, 
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedClicksPerRegion.size, 30000)
+    streams.close()
+    assertEquals(l.sortBy(_.key), expectedClicksPerRegion.sortBy(_.key))
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = { 
+      // println(s"Get Message $record")
+    }
+  }
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestImplicitSerdesWithExplicitJoined.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestImplicitSerdesWithExplicitJoined.scala
@@ -1,0 +1,199 @@
+/**
+  * Copyright (C) 2018 OpenShine SL <https://www.openshine.com>
+  * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+  * Adapted from Confluent Inc. whose copyright is reproduced below.
+  */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import java.util.Properties
+
+import com.lightbend.kafka.scala.server.{KafkaLocalServer, MessageListener, MessageSender, RecordProcessorTrait}
+import com.lightbend.kafka.scala.streams.StreamToTableJoinTestData
+import minitest.TestSuite
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
+import org.apache.kafka.streams.kstream.Joined
+
+object StreamToTableJoinScalaIntegrationTestImplicitSerdesWithExplicitJoined
+  extends TestSuite[KafkaLocalServer] with StreamToTableJoinTestData {
+
+  /**
+    * End-to-end integration test that demonstrates how to perform a join
+    * between a KStream and a
+    * KTable (think: KStream.leftJoin(KTable)), i.e. an example of a stateful
+    * computation.
+    *
+    * See StreamToTableJoinIntegrationTest for the equivalent Java example.
+    *
+    * Note: We intentionally use JUnit4 (wrapped by ScalaTest) for
+    * implementing this Scala integration
+    * test so it is easier to compare this Scala code with the equivalent
+    * Java code at
+    * StreamToTableJoinIntegrationTest.  One difference is that, to simplify
+    * the Scala/Junit integration, we
+    * switched from BeforeClass (which must be `static`) to Before as well as
+    * from @ClassRule (which
+    * must be `static` and `public`) to a workaround combination of `@Rule
+    * def` and a `private val`.
+    */
+
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count clicks per region") { server =>
+
+    server.createTopic(userClicksTopic)
+    server.createTopic(userRegionsTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p
+        .put(StreamsConfig.APPLICATION_ID_CONFIG,
+          s"stream-table-join-scala-integration-test-implicit-serdes-${
+            scala
+              .util.Random.nextInt(100)
+          }")
+      p
+        .put(StreamsConfig.CLIENT_ID_CONFIG,
+          "join-scala-integration-test-implicit-serdes-standard-consumer")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+      p
+    }
+
+    import SerdeDerivations._
+    implicit val builder = new StreamsBuilder()
+
+    val userClicksStream: TSKStream[String, Long] = TSKStream(userClicksTopic)
+
+    val userRegionsTable: TSKTable[String, String] = TSKTable(userRegionsTopic)
+
+    // Compute the total per region by summing the individual click counts
+    // per region.
+    val clicksPerRegion: TSKTable[String, Long] =
+      userClicksStream
+
+        // Join the stream against the table.
+        .leftJoin(
+        userRegionsTable,
+        (clicks: Long, region: String) =>
+          (if (region == null) "UNKNOWN" else region, clicks))(
+        // If the user provides an explicit Joined instance, the implicit is
+        // not resolved and their instance is used instead. Beware that this
+        // means that the user can STILL inject an invalid Joined instance
+        // due to the lax type restrictions that come with the Joined
+        // constructors.
+        Joined.keySerde(stringSerde).withValueSerde(scalaLongSerde))
+
+        // Change the stream from <user> -> <region, clicks> to <region> ->
+        // <clicks>
+        .map((_, regionWithClicks) => regionWithClicks)
+
+        // Compute the total per region by summing the individual click
+        // counts per region.
+        .groupByKey
+        .reduce(_ + _)
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic)
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build,
+      streamsConfiguration)
+
+    streams
+      .setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+        override def uncaughtException(t: Thread, e: Throwable): Unit = try {
+          println(
+            s"Stream terminated because of uncaught exception .. Shutting " +
+              s"down app",
+
+            e)
+          e.printStackTrace
+          val closed = streams.close()
+          println(s"Exiting application after streams close ($closed)")
+        } catch {
+          case x: Exception => x.printStackTrace
+        } finally {
+          println("Exiting application ..")
+          System.exit(-1)
+        }
+      })
+
+    streams.start()
+
+    //
+    // Step 2: Publish user-region information.
+    //
+    // To keep this code example simple and easier to understand/reason
+    // about, we publish all
+    // user-region records before any user-click records (cf. step 3).  In
+    // practice though,
+    // data records would typically be arriving concurrently in both input
+    // streams/topics.
+    val sender1 = MessageSender[String, String](brokers,
+      classOf[StringSerializer].getName, classOf[StringSerializer].getName)
+    userRegions
+      .foreach(r => sender1.writeKeyValue(userRegionsTopic, r.key, r.value))
+
+    //
+    // Step 3: Publish some user click events.
+    //
+    val sender2 = MessageSender[String, Long](brokers,
+      classOf[StringSerializer].getName, classOf[LongSerializer].getName)
+    userClicks
+      .foreach(r => sender2.writeKeyValue(userClicksTopic, r.key, r.value))
+
+    //
+    // Step 4: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic,
+      "join-scala-integration-test-standard-consumer",
+      classOf[StringDeserializer].getName,
+      classOf[LongDeserializer].getName,
+      new RecordProcessor
+    )
+
+    val l = listener
+      .waitUntilMinKeyValueRecordsReceived(expectedClicksPerRegion.size,
+        30000)
+    streams.close()
+    assertEquals(l.sortBy(_.key), expectedClicksPerRegion.sortBy(_.key))
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = {
+      // println(s"Get Message $record")
+    }
+  }
+
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestImplicitSerdesWithUnsafelyApi.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestImplicitSerdesWithUnsafelyApi.scala
@@ -1,0 +1,211 @@
+/**
+  * Copyright (C) 2018 OpenShine SL <https://www.openshine.com>
+  * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+  * Adapted from Confluent Inc. whose copyright is reproduced below.
+  */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import java.util.Properties
+
+import com.lightbend.kafka.scala.server.{KafkaLocalServer, MessageListener, MessageSender, RecordProcessorTrait}
+import com.lightbend.kafka.scala.streams.StreamToTableJoinTestData
+import minitest.TestSuite
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
+import org.apache.kafka.streams.kstream.{Joined, KStream}
+
+/**
+  * @author Santiago Saavedra (ssaavedra@openshine.com)
+  */
+object StreamToTableJoinScalaIntegrationTestImplicitSerdesWithUnsafelyApi
+  extends TestSuite[KafkaLocalServer] with StreamToTableJoinTestData {
+
+  /**
+    * End-to-end integration test that demonstrates how to perform a join
+    * between a KStream and a
+    * KTable (think: KStream.leftJoin(KTable)), i.e. an example of a stateful
+    * computation.
+    *
+    * See StreamToTableJoinIntegrationTest for the equivalent Java example.
+    *
+    * Note: We intentionally use JUnit4 (wrapped by ScalaTest) for
+    * implementing this Scala integration
+    * test so it is easier to compare this Scala code with the equivalent
+    * Java code at
+    * StreamToTableJoinIntegrationTest.  One difference is that, to simplify
+    * the Scala/Junit integration, we
+    * switched from BeforeClass (which must be `static`) to Before as well as
+    * from @ClassRule (which
+    * must be `static` and `public`) to a workaround combination of `@Rule
+    * def` and a `private val`.
+    */
+
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count clicks per region") { server =>
+
+    server.createTopic(userClicksTopic)
+    server.createTopic(userRegionsTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p
+        .put(StreamsConfig.APPLICATION_ID_CONFIG,
+          s"stream-table-join-scala-integration-test-implicit-serdes-${
+            scala
+              .util.Random.nextInt(100)
+          }")
+      p
+        .put(StreamsConfig.CLIENT_ID_CONFIG,
+          "join-scala-integration-test-implicit-serdes-standard-consumer")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+      p
+    }
+
+    import ImplicitConverters._
+    import SerdeDerivations._
+    import com.lightbend.kafka.scala.streams.FunctionConversions._
+    import unsafe._
+    implicit val builder = new StreamsBuilder()
+
+    val userClicksStream: TSKStream[String, Long] = TSKStream(userClicksTopic)
+
+    val userRegionsTable: TSKTable[String, String] = TSKTable(userRegionsTopic)
+
+
+    // Compute the total per region by summing the individual click counts
+    // per region.
+    val clicksPerRegion: TSKTable[String, Long] =
+    userClicksStream
+
+      // Join the stream against the table.
+      // Here, we use the `unsafely` API to work on the underlying object
+      // while still returning a typesafe result. We could remove the type
+      // annotation in the unsafely call, but it helps IDEs to find the
+      // appropriate return value when chaining calls afterwards.
+      .unsafely[String, (String, Long), KStream, TSKStream] {
+      _.leftJoin[String, (String, Long)](
+        userRegionsTable.unsafe, {
+          (clicks: Long, region: String) =>
+            (if (region == null) "UNKNOWN" else region, clicks)
+        }.asValueJoiner,
+        Joined
+          .keySerde[String, Long, String](stringSerde)
+          .withValueSerde(scalaLongSerde))
+    }
+      // Change the stream from <user> -> <region, clicks> to <region> ->
+      // <clicks>
+      .map((_, regionWithClicks) => regionWithClicks)
+
+      // Compute the total per region by summing the individual click
+      // counts per region.
+      .groupByKey
+      .reduce(_ + _)
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic)
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build,
+      streamsConfiguration)
+
+    streams
+      .setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+        override def uncaughtException(t: Thread, e: Throwable): Unit = try {
+          println(
+            s"Stream terminated because of uncaught exception .. Shutting " +
+              s"down app",
+
+            e)
+          e.printStackTrace
+          val closed = streams.close()
+          println(s"Exiting application after streams close ($closed)")
+        } catch {
+          case x: Exception => x.printStackTrace
+        } finally {
+          println("Exiting application ..")
+          System.exit(-1)
+        }
+      })
+
+    streams.start()
+
+    //
+    // Step 2: Publish user-region information.
+    //
+    // To keep this code example simple and easier to understand/reason
+    // about, we publish all
+    // user-region records before any user-click records (cf. step 3).  In
+    // practice though,
+    // data records would typically be arriving concurrently in both input
+    // streams/topics.
+    val sender1 = MessageSender[String, String](brokers,
+      classOf[StringSerializer].getName, classOf[StringSerializer].getName)
+    userRegions
+      .foreach(r => sender1.writeKeyValue(userRegionsTopic, r.key, r.value))
+
+    //
+    // Step 3: Publish some user click events.
+    //
+    val sender2 = MessageSender[String, Long](brokers,
+      classOf[StringSerializer].getName, classOf[LongSerializer].getName)
+    userClicks
+      .foreach(r => sender2.writeKeyValue(userClicksTopic, r.key, r.value))
+
+    //
+    // Step 4: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic,
+      "join-scala-integration-test-standard-consumer",
+      classOf[StringDeserializer].getName,
+      classOf[LongDeserializer].getName,
+      new RecordProcessor
+    )
+
+    val l = listener
+      .waitUntilMinKeyValueRecordsReceived(expectedClicksPerRegion.size,
+        30000)
+    streams.close()
+    assertEquals(l.sortBy(_.key), expectedClicksPerRegion.sortBy(_.key))
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = {
+      // println(s"Get Message $record")
+    }
+  }
+
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestImplicitSerialized.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestImplicitSerialized.scala
@@ -1,0 +1,156 @@
+/**
+  * Copyright (C) 2018 OpenShine SL <https://www.openshine.com>
+  * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+  * Adapted from Confluent Inc. whose copyright is reproduced below.
+  */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import java.util.Properties
+
+import com.lightbend.kafka.scala.server.{KafkaLocalServer, MessageListener, MessageSender, RecordProcessorTrait}
+import com.lightbend.kafka.scala.streams.StreamToTableJoinTestData
+import minitest.TestSuite
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
+
+/**
+  * End-to-end integration test that demonstrates how to perform a join between a KStream and a
+  * KTable (think: KStream.leftJoin(KTable)), i.e. an example of a stateful computation.
+  *
+  * See StreamToTableJoinIntegrationTest for the equivalent Java example.
+  *
+  * Note: We intentionally use JUnit4 (wrapped by ScalaTest) for implementing this Scala integration
+  * test so it is easier to compare this Scala code with the equivalent Java code at
+  * StreamToTableJoinIntegrationTest.  One difference is that, to simplify the Scala/Junit integration, we
+  * switched from BeforeClass (which must be `static`) to Before as well as from @ClassRule (which
+  * must be `static` and `public`) to a workaround combination of `@Rule def` and a `private val`.
+  */
+
+object StreamToTableJoinScalaIntegrationTestImplicitSerialized extends TestSuite[KafkaLocalServer] with StreamToTableJoinTestData {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count clicks per region") { server =>
+
+    server.createTopic(userClicksTopic)
+    server.createTopic(userRegionsTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p.put(StreamsConfig.APPLICATION_ID_CONFIG, s"stream-table-join-scala-integration-test-implicit-ser-${scala.util.Random.nextInt(100)}")
+      p.put(StreamsConfig.CLIENT_ID_CONFIG, "join-scala-integration-test-implicit-ser-standard-consumer")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+      p
+    }
+
+    import SerdeDerivations._
+
+    implicit val builder = new StreamsBuilder()
+
+    val userClicksStream: TSKStream[String, Long] = TSKStream(userClicksTopic)
+
+    val userRegionsTable: TSKTable[String, String] = TSKTable(userRegionsTopic)
+
+    // Compute the total per region by summing the individual click counts per region.
+    val clicksPerRegion: TSKTable[String, Long] =
+      userClicksStream
+
+        // Join the stream against the table.
+        .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
+
+        // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+        .map((_, regionWithClicks) => regionWithClicks)
+
+        // Compute the total per region by summing the individual click counts per region.
+        .groupByKey
+        .reduce(_ + _)
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic)
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build, streamsConfiguration)
+
+    streams.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      override def uncaughtException(t: Thread, e: Throwable): Unit = try {
+        println(s"Stream terminated because of uncaught exception .. Shutting down app", e)
+        e.printStackTrace
+        val closed = streams.close()
+        println(s"Exiting application after streams close ($closed)")
+      } catch {
+        case x: Exception => x.printStackTrace
+      } finally {
+        println("Exiting application ..")
+        System.exit(-1)
+      }
+    })
+
+    streams.start()
+
+    //
+    // Step 2: Publish user-region information.
+    //
+    // To keep this code example simple and easier to understand/reason about, we publish all
+    // user-region records before any user-click records (cf. step 3).  In practice though,
+    // data records would typically be arriving concurrently in both input streams/topics.
+    val sender1 = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName) 
+    userRegions.foreach(r => sender1.writeKeyValue(userRegionsTopic, r.key, r.value))
+
+    //
+    // Step 3: Publish some user click events.
+    //
+    val sender2 = MessageSender[String, Long](brokers, classOf[StringSerializer].getName, classOf[LongSerializer].getName) 
+    userClicks.foreach(r => sender2.writeKeyValue(userClicksTopic, r.key, r.value))
+
+    //
+    // Step 4: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "join-scala-integration-test-standard-consumer", 
+      classOf[StringDeserializer].getName, 
+      classOf[LongDeserializer].getName, 
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedClicksPerRegion.size, 30000)
+    streams.close()
+    assertEquals(l.sortBy(_.key), expectedClicksPerRegion.sortBy(_.key))
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = { 
+      // println(s"Get Message $record")
+    }
+  }
+}

--- a/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestMixImplicitSerialized.scala
+++ b/src/test/scala/com/lightbend/kafka/scala/streams/typesafe/StreamToTableJoinScalaIntegrationTestMixImplicitSerialized.scala
@@ -1,0 +1,161 @@
+/**
+  * Copyright (C) 2018 OpenShine SL <https://www.openshine.com>
+  * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+  * Adapted from Confluent Inc. whose copyright is reproduced below.
+  */
+
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lightbend.kafka.scala.streams.typesafe
+
+import java.util.Properties
+
+import com.lightbend.kafka.scala.server.{KafkaLocalServer, MessageListener, MessageSender, RecordProcessorTrait}
+import com.lightbend.kafka.scala.streams.StreamToTableJoinTestData
+import minitest.TestSuite
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
+import org.apache.kafka.streams.kstream.Produced
+
+/**
+  * End-to-end integration test that demonstrates how to perform a join between a KStream and a
+  * KTable (think: KStream.leftJoin(KTable)), i.e. an example of a stateful computation.
+  *
+  * See StreamToTableJoinIntegrationTest for the equivalent Java example.
+  *
+  * Note: We intentionally use JUnit4 (wrapped by ScalaTest) for implementing this Scala integration
+  * test so it is easier to compare this Scala code with the equivalent Java code at
+  * StreamToTableJoinIntegrationTest.  One difference is that, to simplify the Scala/Junit integration, we
+  * switched from BeforeClass (which must be `static`) to Before as well as from @ClassRule (which
+  * must be `static` and `public`) to a workaround combination of `@Rule def` and a `private val`.
+  */
+
+object StreamToTableJoinScalaIntegrationTestMixImplicitSerialized
+  extends TestSuite[KafkaLocalServer]
+    with StreamToTableJoinTestData
+    with SerdeDerivations {
+
+  override def setup(): KafkaLocalServer = {
+    val s = KafkaLocalServer(true, Some(localStateDir))
+    s.start()
+    s
+  }
+
+  override def tearDown(server: KafkaLocalServer): Unit = {
+    server.stop()
+  }
+
+  test("should count clicks per region") { server =>
+
+    server.createTopic(userClicksTopic)
+    server.createTopic(userRegionsTopic)
+    server.createTopic(outputTopic)
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    val streamsConfiguration: Properties = {
+      val p = new Properties()
+      p.put(StreamsConfig.APPLICATION_ID_CONFIG, s"stream-table-join-scala-integration-test-mix-implicit-ser-${scala.util.Random.nextInt(100)}")
+      p.put(StreamsConfig.CLIENT_ID_CONFIG, "join-scala-integration-test-mix-implicit-ser-standard-consumer")
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+      p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
+      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100")
+      p.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
+      p
+    }
+
+    implicit val builder = new StreamsBuilder()
+
+    val userClicksStream: TSKStream[String, Long] = TSKStream(userClicksTopic)
+
+    // this will use the default serdes set in config
+    val userRegionsTable: TSKTable[String, String] = TSKTable(userRegionsTopic)
+
+    // Compute the total per region by summing the individual click counts per region.
+    val clicksPerRegion: TSKTable[String, Long] =
+      userClicksStream
+
+        // Join the stream against the table.
+        .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
+
+        // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+        .map((_, regionWithClicks) => regionWithClicks)
+
+        // Compute the total per region by summing the individual click counts per region.
+        .groupByKey
+        .reduce(_ + _)
+
+    // Write the (continuously updating) results to the output topic.
+    clicksPerRegion.toStream.to(outputTopic)(
+      Produced.`with`(implicitly[Serde[String]], implicitly[Serde[Long]]))
+
+    val streams: KafkaStreams = new KafkaStreams(builder.build, streamsConfiguration)
+
+    streams.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      override def uncaughtException(t: Thread, e: Throwable): Unit = try {
+        println(s"Stream terminated because of uncaught exception .. Shutting down app", e)
+        e.printStackTrace
+        val closed = streams.close()
+        println(s"Exiting application after streams close ($closed)")
+      } catch {
+        case x: Exception => x.printStackTrace
+      } finally {
+        println("Exiting application ..")
+        System.exit(-1)
+      }
+    })
+
+    streams.start()
+
+    //
+    // Step 2: Publish user-region information.
+    //
+    // To keep this code example simple and easier to understand/reason about, we publish all
+    // user-region records before any user-click records (cf. step 3).  In practice though,
+    // data records would typically be arriving concurrently in both input streams/topics.
+    val sender1 = MessageSender[String, String](brokers, classOf[StringSerializer].getName, classOf[StringSerializer].getName) 
+    userRegions.foreach(r => sender1.writeKeyValue(userRegionsTopic, r.key, r.value))
+
+    //
+    // Step 3: Publish some user click events.
+    //
+    val sender2 = MessageSender[String, Long](brokers, classOf[StringSerializer].getName, classOf[LongSerializer].getName) 
+    userClicks.foreach(r => sender2.writeKeyValue(userClicksTopic, r.key, r.value))
+
+    //
+    // Step 4: Verify the application's output data.
+    //
+    val listener = MessageListener(brokers, outputTopic, "join-scala-integration-test-standard-consumer", 
+      classOf[StringDeserializer].getName, 
+      classOf[LongDeserializer].getName, 
+      new RecordProcessor
+    )
+
+    val l = listener.waitUntilMinKeyValueRecordsReceived(expectedClicksPerRegion.size, 30000)
+    streams.close()
+    assertEquals(l.sortBy(_.key), expectedClicksPerRegion.sortBy(_.key))
+  }
+
+  class RecordProcessor extends RecordProcessorTrait[String, Long] {
+    override def processRecord(record: ConsumerRecord[String, Long]): Unit = { 
+      // println(s"Get Message $record")
+    }
+  }
+}
+


### PR DESCRIPTION
Enable a type *safer* API for kafka-streams.

This PR creates new abstractions (named `TS-` from the base objects in the underlying library) which enable a more type safe abstraction than the provided default.

This does not use the Perhaps pattern and requires some implicit value to be always present in order to call the methods, which ensures no compile-time errors are transformed into runtime exceptions where avoidable.

You can still perform unsafe operations by calling the `.unsafely` handler, which will perform your operation in the underlying data type and still wrap it into the type safe operator when finished, so if you import the UnsafelyWrapper implicit class you can still make use of the default Serdes, but you can't *by default* so you will catch serialization errors unless you explicitly request to avoid so.