### PR TITLE
Fix KGroupedStream#reduce to ensure proper serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: oraclejdk8
 scala:
 - 2.11.11
 - 2.12.4
-sbt_args: -mem 1500
+sbt_args: -mem 2000
 script:
 - sbt "++ ${TRAVIS_SCALA_VERSION}!" test
 cache:


### PR DESCRIPTION
One of the overloads of `KGroupedStream#reduce` needed to have implicit serdes for proper serialization through `Materialized`.

Fixes https://github.com/lightbend/kafka-streams-scala/issues/57