### PR TITLE
Long to SessionWindows implicit conversion

### DIFF
--- a/src/main/scala/com/lightbend/kafka/scala/streams/ImplicitConversions.scala
+++ b/src/main/scala/com/lightbend/kafka/scala/streams/ImplicitConversions.scala
@@ -53,4 +53,6 @@ object ImplicitConversions {
                                             valueSerde: Serde[V],
                                             otherValueSerde: Serde[VO]): Joined[K, V, VO] =
     Joined.`with`(keySerde, valueSerde, otherValueSerde)
+
+  implicit def longToSessionWindows(x: Long): SessionWindows = SessionWindows.`with`(x)
 }


### PR DESCRIPTION
Just some syntactic sugar with an implicit conversion from Long to Session Windows to use the ```windowedBy``` function this way:
```scala
stream
  .groupBy(something)
  .windowedBy(5l)
```